### PR TITLE
Apply changes to upstream

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -95,9 +95,9 @@ jobs:
         run: |
           kubectl create ns samples
           kubectl -n samples apply -f config/samples
-          kubectl -n samples wait hr/podinfo-ocirepository --for=condition=ready --timeout=4m
-          kubectl -n samples wait hr/podinfo-gitrepository --for=condition=ready --timeout=4m
-          kubectl -n samples wait hr/podinfo-helmrepository --for=condition=ready --timeout=4m
+          kubectl -n samples wait qdranthr/podinfo-ocirepository --for=condition=ready --timeout=4m
+          kubectl -n samples wait qdranthr/podinfo-gitrepository --for=condition=ready --timeout=4m
+          kubectl -n samples wait qdranthr/podinfo-helmrepository --for=condition=ready --timeout=4m
           kubectl delete ns samples
       - name: Install sources
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.so
 *.dylib
 bin
+.env
 
 # Test binary, build with `go test -c`
 *.test
@@ -23,3 +24,4 @@ bin
 *~
 
 build/
+vendor/

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ CRD_DEP_ROOT ?= $(BUILD_DIR)/config/crd/bases
 # Keep a record of the version of the downloaded source CRDs. It is used to
 # detect and download new CRDs when the SOURCE_VER changes.
 SOURCE_VER ?= $(shell go list -m all | grep github.com/fluxcd/source-controller/api | awk '{print $$2}')
-SOURCE_BRANCH ?= main
+SOURCE_BRANCH ?= d650fb97fa04e71a9607808189040502c928b5bf
 SOURCE_CRD_VER = $(CRD_DEP_ROOT)/.src-crd-$(SOURCE_VER)
 
 # HelmChart source CRD.

--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,11 @@ CRD_DEP_ROOT ?= $(BUILD_DIR)/config/crd/bases
 # Keep a record of the version of the downloaded source CRDs. It is used to
 # detect and download new CRDs when the SOURCE_VER changes.
 SOURCE_VER ?= $(shell go list -m all | grep github.com/fluxcd/source-controller/api | awk '{print $$2}')
+SOURCE_BRANCH ?= main
 SOURCE_CRD_VER = $(CRD_DEP_ROOT)/.src-crd-$(SOURCE_VER)
 
 # HelmChart source CRD.
-HELMCHART_SOURCE_CRD ?= $(CRD_DEP_ROOT)/source.toolkit.fluxcd.io_helmcharts.yaml
+HELMCHART_SOURCE_CRD ?= $(CRD_DEP_ROOT)/cd.qdrant.io_helmcharts.yaml
 
 # API (doc) generation utilities
 CONTROLLER_GEN_VERSION ?= v0.15.0
@@ -46,7 +47,7 @@ all: manager
 
 # Run tests
 KUBEBUILDER_ASSETS?="$(shell $(ENVTEST) --arch=$(ENVTEST_ARCH) use -i $(ENVTEST_KUBERNETES_VERSION) --bin-dir=$(ENVTEST_ASSETS_DIR) -p path)"
-test: tidy generate fmt vet manifests api-docs install-envtest download-crd-deps
+test: tidy generate fmt vet manifests install-envtest download-crd-deps
 	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./... -coverprofile cover.out
 	cd api; go test ./... -coverprofile cover.out
 
@@ -133,7 +134,7 @@ $(SOURCE_CRD_VER):
 	touch $(SOURCE_CRD_VER)
 
 $(HELMCHART_SOURCE_CRD):
-	curl -s https://raw.githubusercontent.com/fluxcd/source-controller/${SOURCE_VER}/config/crd/bases/source.toolkit.fluxcd.io_helmcharts.yaml > $(HELMCHART_SOURCE_CRD)
+	curl -s https://raw.githubusercontent.com/qdrant/fluxcd-source-controller/${SOURCE_BRANCH}/config/crd/bases/cd.qdrant.io_helmcharts.yaml > $(HELMCHART_SOURCE_CRD)
 
 # Download the CRDs the controller depends on
 download-crd-deps: $(SOURCE_CRD_VER) $(HELMCHART_SOURCE_CRD)

--- a/PROJECT
+++ b/PROJECT
@@ -1,13 +1,13 @@
-domain: toolkit.fluxcd.io
+domain: qdrant.io
 repo: github.com/fluxcd/helm-controller
 resources:
-- group: helm
+- group: cd
   kind: HelmRelease
   version: v2beta1
-- group: helm
+- group: cd
   kind: HelmRelease
   version: v2beta2
-- group: helm
+- group: cd
   kind: HelmRelease
   version: v2
 storageVersion: v2

--- a/README.md
+++ b/README.md
@@ -6,6 +6,42 @@
 [![license](https://img.shields.io/github/license/fluxcd/helm-controller.svg)](https://github.com/fluxcd/helm-controller/blob/main/LICENSE)
 [![release](https://img.shields.io/github/release/fluxcd/helm-controller/all.svg)](https://github.com/fluxcd/helm-controller/releases)
 
+## About this fork
+
+This fork is used by the
+[qdrant-cloud-agent](https://github.com/qdrant/qdrant-cloud-agent/). The main
+reason behind forking the upstream project is to be able to distribute the CRDs of this
+project without risk of collision in case the customer is using Flux CD in their
+K8s cluster. The main change between the fork and upstream consist of renaming the
+API group names, replacing the ones from fluxcd (ex: `helm.toolkit.fluxcd.io`)
+by our custom ones.
+
+### Maintaining the fork up to date
+
+- Configure and fetch upstream/main.
+- Create your development branch from origin/main and merge upstream/main into
+  it. You can run the merge with `-X theirs` option.
+- Solve the git conflicts if any.
+- As there might be new files or content added in upstream, we might need to
+  rename groups again. You can do that executing
+  `./scripts/rename-api-groups.sh`.
+- You are probably updating [source-controller](https://github.com/fluxcd/source-controller) as well. If that's the case, you
+  need to update the dependency in this project. 
+  - Update the `SOURCE_BRANCH` var in the Makefile with the new commit
+  - Update go.mod: `go mod edit -replace github.com/fluxcd/source-controller/api=github.com/qdrant/fluxcd-source-controller/api@PLACE_HERE_THE_NEW_COMMIT_SHA`
+- Run `go mod tidy` to clean up the dependencies and execute the tests of the project with `make test`.
+- Ideally, they are passing. Otherwise, you need to work on fixing any possible
+  issue.
+- Push your development branch. After that, you would need to test it using it
+  in the cloud-agent to confirm everything works as expected.
+- Once you confirm it works fine, create a PR for review.
+- **Note for the reviewer:** The merge commit from upstream/main doesn't make
+  sense to review it. Focus on the commits with the changes relevant for the
+  project.
+
+
+---
+
 The helm-controller is a Kubernetes operator, allowing one to declaratively
 manage Helm chart releases. It is part of a composable [GitOps toolkit](https://fluxcd.io/flux/components)
 and depends on [source-controller][] to acquire the Helm charts from Helm

--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -1,0 +1,55 @@
+package adapter
+
+import (
+	"context"
+	"time"
+
+	runtimeClient "github.com/fluxcd/pkg/runtime/client"
+	helper "github.com/fluxcd/pkg/runtime/controller"
+	"github.com/fluxcd/pkg/runtime/events"
+
+	"github.com/fluxcd/helm-controller/internal/controller"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type HelmReleaseAdapter struct {
+	ClientOpts        runtimeClient.Options
+	KubeConfigOpts    runtimeClient.KubeConfigOptions
+	ReconcilerOptions HelmReleaseReconcilerOption
+	ControllerName    string
+	MetricOptions     helper.Metrics
+	LeaderElection    *bool
+}
+
+type HelmReleaseReconcilerOption struct {
+	HTTPRetry                 int
+	DependencyRequeueInterval time.Duration
+	RateLimiter               workqueue.TypedRateLimiter[reconcile.Request]
+}
+
+func SetupHelmReconciler(ctx context.Context, mgr ctrl.Manager, adapter *HelmReleaseAdapter) error {
+	var eventRecorder *events.Recorder
+	var err error
+
+	if eventRecorder, err = events.NewRecorder(mgr, mgr.GetLogger(), "", adapter.ControllerName); err != nil {
+		return err
+	}
+
+	hr := &controller.HelmReleaseReconciler{
+		Client:           mgr.GetClient(),
+		EventRecorder:    eventRecorder,
+		Metrics:          adapter.MetricOptions,
+		GetClusterConfig: ctrl.GetConfig,
+		ClientOpts:       adapter.ClientOpts,
+		KubeConfigOpts:   adapter.KubeConfigOpts,
+		LeaderElection:   adapter.LeaderElection,
+		FieldManager:     adapter.ControllerName,
+	}
+	return hr.SetupWithManager(ctx, mgr, controller.HelmReleaseReconcilerOptions{
+		DependencyRequeueInterval: adapter.ReconcilerOptions.DependencyRequeueInterval,
+		HTTPRetry:                 adapter.ReconcilerOptions.HTTPRetry,
+		RateLimiter:               adapter.ReconcilerOptions.RateLimiter,
+	})
+}

--- a/api/v2/doc.go
+++ b/api/v2/doc.go
@@ -16,5 +16,5 @@ limitations under the License.
 
 // Package v2 contains API Schema definitions for the helm v2 API group
 // +kubebuilder:object:generate=true
-// +groupName=helm.toolkit.fluxcd.io
+// +groupName=cd.qdrant.io
 package v2

--- a/api/v2/groupversion_info.go
+++ b/api/v2/groupversion_info.go
@@ -23,7 +23,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "helm.toolkit.fluxcd.io", Version: "v2"}
+	GroupVersion = schema.GroupVersion{Group: "cd.qdrant.io", Version: "v2"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/api/v2/helmrelease_types.go
+++ b/api/v2/helmrelease_types.go
@@ -34,7 +34,7 @@ const (
 	HelmReleaseKind = "HelmRelease"
 	// HelmReleaseFinalizer is set on a HelmRelease when it is first handled by
 	// the controller, and removed when this object is deleted.
-	HelmReleaseFinalizer = "finalizers.fluxcd.io"
+	HelmReleaseFinalizer = "finalizers.qdrant.io"
 )
 
 const (
@@ -1061,7 +1061,7 @@ const (
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName=hr
+// +kubebuilder:resource:shortName=qdranthr
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""

--- a/api/v2beta1/doc.go
+++ b/api/v2beta1/doc.go
@@ -16,5 +16,5 @@ limitations under the License.
 
 // Package v2beta1 contains API Schema definitions for the helm v2beta1 API group
 // +kubebuilder:object:generate=true
-// +groupName=helm.toolkit.fluxcd.io
+// +groupName=cd.qdrant.io
 package v2beta1

--- a/api/v2beta1/groupversion_info.go
+++ b/api/v2beta1/groupversion_info.go
@@ -23,7 +23,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "helm.toolkit.fluxcd.io", Version: "v2beta1"}
+	GroupVersion = schema.GroupVersion{Group: "cd.qdrant.io", Version: "v2beta1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/api/v2beta1/helmrelease_types.go
+++ b/api/v2beta1/helmrelease_types.go
@@ -34,7 +34,7 @@ import (
 )
 
 const HelmReleaseKind = "HelmRelease"
-const HelmReleaseFinalizer = "finalizers.fluxcd.io"
+const HelmReleaseFinalizer = "finalizers.qdrant.io"
 
 // Kustomize Helm PostRenderer specification.
 type Kustomize struct {
@@ -1096,7 +1096,7 @@ const (
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName=hr
+// +kubebuilder:resource:shortName=qdranthr
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status",description=""

--- a/api/v2beta2/doc.go
+++ b/api/v2beta2/doc.go
@@ -16,5 +16,5 @@ limitations under the License.
 
 // Package v2beta2 contains API Schema definitions for the helm v2beta2 API group
 // +kubebuilder:object:generate=true
-// +groupName=helm.toolkit.fluxcd.io
+// +groupName=cd.qdrant.io
 package v2beta2

--- a/api/v2beta2/groupversion_info.go
+++ b/api/v2beta2/groupversion_info.go
@@ -23,7 +23,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "helm.toolkit.fluxcd.io", Version: "v2beta2"}
+	GroupVersion = schema.GroupVersion{Group: "cd.qdrant.io", Version: "v2beta2"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/api/v2beta2/helmrelease_types.go
+++ b/api/v2beta2/helmrelease_types.go
@@ -36,7 +36,7 @@ const (
 	HelmReleaseKind = "HelmRelease"
 	// HelmReleaseFinalizer is set on a HelmRelease when it is first handled by
 	// the controller, and removed when this object is deleted.
-	HelmReleaseFinalizer = "finalizers.fluxcd.io"
+	HelmReleaseFinalizer = "finalizers.qdrant.io"
 )
 
 const (
@@ -1090,7 +1090,7 @@ const (
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName=hr
+// +kubebuilder:resource:shortName=qdranthr
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status",description=""

--- a/config/crd/bases/cd.qdrant.io_helmreleases.yaml
+++ b/config/crd/bases/cd.qdrant.io_helmreleases.yaml
@@ -1,0 +1,3750 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: helmreleases.cd.qdrant.io
+spec:
+  group: cd.qdrant.io
+  names:
+    kind: HelmRelease
+    listKind: HelmReleaseList
+    plural: helmreleases
+    shortNames:
+    - qdranthr
+    singular: helmrelease
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    name: v2
+    schema:
+      openAPIV3Schema:
+        description: HelmRelease is the Schema for the helmreleases API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HelmReleaseSpec defines the desired state of a Helm release.
+            properties:
+              chart:
+                description: |-
+                  Chart defines the template of the v1.HelmChart that should be created
+                  for this HelmRelease.
+                properties:
+                  metadata:
+                    description: ObjectMeta holds the template for metadata like labels
+                      and annotations.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+                        type: object
+                    type: object
+                  spec:
+                    description: Spec holds the template for the v1.HelmChartSpec
+                      for this HelmRelease.
+                    properties:
+                      chart:
+                        description: The name or path the Helm chart is available
+                          at in the SourceRef.
+                        maxLength: 2048
+                        minLength: 1
+                        type: string
+                      ignoreMissingValuesFiles:
+                        description: IgnoreMissingValuesFiles controls whether to
+                          silently ignore missing values files rather than failing.
+                        type: boolean
+                      interval:
+                        description: |-
+                          Interval at which to check the v1.Source for updates. Defaults to
+                          'HelmReleaseSpec.Interval'.
+                        pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                        type: string
+                      reconcileStrategy:
+                        default: ChartVersion
+                        description: |-
+                          Determines what enables the creation of a new artifact. Valid values are
+                          ('ChartVersion', 'Revision').
+                          See the documentation of the values for an explanation on their behavior.
+                          Defaults to ChartVersion when omitted.
+                        enum:
+                        - ChartVersion
+                        - Revision
+                        type: string
+                      sourceRef:
+                        description: The name and namespace of the v1.Source the chart
+                          is available at.
+                        properties:
+                          apiVersion:
+                            description: APIVersion of the referent.
+                            type: string
+                          kind:
+                            description: Kind of the referent.
+                            enum:
+                            - HelmRepository
+                            - GitRepository
+                            - Bucket
+                            type: string
+                          name:
+                            description: Name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: Namespace of the referent.
+                            maxLength: 63
+                            minLength: 1
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      valuesFiles:
+                        description: |-
+                          Alternative list of values files to use as the chart values (values.yaml
+                          is not included by default), expected to be a relative path in the SourceRef.
+                          Values files are merged in the order of this list with the last file overriding
+                          the first. Ignored when omitted.
+                        items:
+                          type: string
+                        type: array
+                      verify:
+                        description: |-
+                          Verify contains the secret name containing the trusted public keys
+                          used to verify the signature and specifies which provider to use to check
+                          whether OCI image is authentic.
+                          This field is only supported for OCI sources.
+                          Chart dependencies, which are not bundled in the umbrella chart artifact,
+                          are not verified.
+                        properties:
+                          provider:
+                            default: cosign
+                            description: Provider specifies the technology used to
+                              sign the OCI Helm chart.
+                            enum:
+                            - cosign
+                            - notation
+                            type: string
+                          secretRef:
+                            description: |-
+                              SecretRef specifies the Kubernetes Secret containing the
+                              trusted public keys.
+                            properties:
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                        required:
+                        - provider
+                        type: object
+                      version:
+                        default: '*'
+                        description: |-
+                          Version semver expression, ignored for charts from v1.GitRepository and
+                          v1beta2.Bucket sources. Defaults to latest when omitted.
+                        type: string
+                    required:
+                    - chart
+                    - sourceRef
+                    type: object
+                required:
+                - spec
+                type: object
+              chartRef:
+                description: |-
+                  ChartRef holds a reference to a source controller resource containing the
+                  Helm chart artifact.
+                properties:
+                  apiVersion:
+                    description: APIVersion of the referent.
+                    type: string
+                  kind:
+                    description: Kind of the referent.
+                    enum:
+                    - OCIRepository
+                    - HelmChart
+                    type: string
+                  name:
+                    description: Name of the referent.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent, defaults to the namespace of the Kubernetes
+                      resource object that contains the reference.
+                    maxLength: 63
+                    minLength: 1
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              dependsOn:
+                description: |-
+                  DependsOn may contain a meta.NamespacedObjectReference slice with
+                  references to HelmRelease resources that must be ready before this HelmRelease
+                  can be reconciled.
+                items:
+                  description: |-
+                    NamespacedObjectReference contains enough information to locate the referenced Kubernetes resource object in any
+                    namespace.
+                  properties:
+                    name:
+                      description: Name of the referent.
+                      type: string
+                    namespace:
+                      description: Namespace of the referent, when not specified it
+                        acts as LocalObjectReference.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              driftDetection:
+                description: |-
+                  DriftDetection holds the configuration for detecting and handling
+                  differences between the manifest in the Helm storage and the resources
+                  currently existing in the cluster.
+                properties:
+                  ignore:
+                    description: |-
+                      Ignore contains a list of rules for specifying which changes to ignore
+                      during diffing.
+                    items:
+                      description: |-
+                        IgnoreRule defines a rule to selectively disregard specific changes during
+                        the drift detection process.
+                      properties:
+                        paths:
+                          description: |-
+                            Paths is a list of JSON Pointer (RFC 6901) paths to be excluded from
+                            consideration in a Kubernetes object.
+                          items:
+                            type: string
+                          type: array
+                        target:
+                          description: |-
+                            Target is a selector for specifying Kubernetes objects to which this
+                            rule applies.
+                            If Target is not set, the Paths will be ignored for all Kubernetes
+                            objects within the manifest of the Helm release.
+                          properties:
+                            annotationSelector:
+                              description: |-
+                                AnnotationSelector is a string that follows the label selection expression
+                                https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                It matches with the resource annotations.
+                              type: string
+                            group:
+                              description: |-
+                                Group is the API group to select resources from.
+                                Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                              type: string
+                            kind:
+                              description: |-
+                                Kind of the API Group to select resources from.
+                                Together with Group and Version it is capable of unambiguously
+                                identifying and/or selecting resources.
+                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                              type: string
+                            labelSelector:
+                              description: |-
+                                LabelSelector is a string that follows the label selection expression
+                                https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                It matches with the resource labels.
+                              type: string
+                            name:
+                              description: Name to match resources with.
+                              type: string
+                            namespace:
+                              description: Namespace to select resources from.
+                              type: string
+                            version:
+                              description: |-
+                                Version of the API Group to select resources from.
+                                Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                              type: string
+                          type: object
+                      required:
+                      - paths
+                      type: object
+                    type: array
+                  mode:
+                    description: |-
+                      Mode defines how differences should be handled between the Helm manifest
+                      and the manifest currently applied to the cluster.
+                      If not explicitly set, it defaults to DiffModeDisabled.
+                    enum:
+                    - enabled
+                    - warn
+                    - disabled
+                    type: string
+                type: object
+              install:
+                description: Install holds the configuration for Helm install actions
+                  for this HelmRelease.
+                properties:
+                  crds:
+                    description: |-
+                      CRDs upgrade CRDs from the Helm Chart's crds directory according
+                      to the CRD upgrade policy provided here. Valid values are `Skip`,
+                      `Create` or `CreateReplace`. Default is `Create` and if omitted
+                      CRDs are installed but not updated.
+
+
+                      Skip: do neither install nor replace (update) any CRDs.
+
+
+                      Create: new CRDs are created, existing CRDs are neither updated nor deleted.
+
+
+                      CreateReplace: new CRDs are created, existing CRDs are updated (replaced)
+                      but not deleted.
+
+
+                      By default, CRDs are applied (installed) during Helm install action.
+                      With this option users can opt in to CRD replace existing CRDs on Helm
+                      install actions, which is not (yet) natively supported by Helm.
+                      https://helm.sh/docs/chart_best_practices/custom_resource_definitions.
+                    enum:
+                    - Skip
+                    - Create
+                    - CreateReplace
+                    type: string
+                  createNamespace:
+                    description: |-
+                      CreateNamespace tells the Helm install action to create the
+                      HelmReleaseSpec.TargetNamespace if it does not exist yet.
+                      On uninstall, the namespace will not be garbage collected.
+                    type: boolean
+                  disableHooks:
+                    description: DisableHooks prevents hooks from running during the
+                      Helm install action.
+                    type: boolean
+                  disableOpenAPIValidation:
+                    description: |-
+                      DisableOpenAPIValidation prevents the Helm install action from validating
+                      rendered templates against the Kubernetes OpenAPI Schema.
+                    type: boolean
+                  disableWait:
+                    description: |-
+                      DisableWait disables the waiting for resources to be ready after a Helm
+                      install has been performed.
+                    type: boolean
+                  disableWaitForJobs:
+                    description: |-
+                      DisableWaitForJobs disables waiting for jobs to complete after a Helm
+                      install has been performed.
+                    type: boolean
+                  remediation:
+                    description: |-
+                      Remediation holds the remediation configuration for when the Helm install
+                      action for the HelmRelease fails. The default is to not perform any action.
+                    properties:
+                      ignoreTestFailures:
+                        description: |-
+                          IgnoreTestFailures tells the controller to skip remediation when the Helm
+                          tests are run after an install action but fail. Defaults to
+                          'Test.IgnoreFailures'.
+                        type: boolean
+                      remediateLastFailure:
+                        description: |-
+                          RemediateLastFailure tells the controller to remediate the last failure, when
+                          no retries remain. Defaults to 'false'.
+                        type: boolean
+                      retries:
+                        description: |-
+                          Retries is the number of retries that should be attempted on failures before
+                          bailing. Remediation, using an uninstall, is performed between each attempt.
+                          Defaults to '0', a negative integer equals to unlimited retries.
+                        type: integer
+                    type: object
+                  replace:
+                    description: |-
+                      Replace tells the Helm install action to re-use the 'ReleaseName', but only
+                      if that name is a deleted release which remains in the history.
+                    type: boolean
+                  skipCRDs:
+                    description: |-
+                      SkipCRDs tells the Helm install action to not install any CRDs. By default,
+                      CRDs are installed if not already present.
+
+
+                      Deprecated use CRD policy (`crds`) attribute with value `Skip` instead.
+                    type: boolean
+                  timeout:
+                    description: |-
+                      Timeout is the time to wait for any individual Kubernetes operation (like
+                      Jobs for hooks) during the performance of a Helm install action. Defaults to
+                      'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              interval:
+                description: Interval at which to reconcile the Helm release.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              kubeConfig:
+                description: |-
+                  KubeConfig for reconciling the HelmRelease on a remote cluster.
+                  When used in combination with HelmReleaseSpec.ServiceAccountName,
+                  forces the controller to act on behalf of that Service Account at the
+                  target cluster.
+                  If the --default-service-account flag is set, its value will be used as
+                  a controller level fallback for when HelmReleaseSpec.ServiceAccountName
+                  is empty.
+                properties:
+                  secretRef:
+                    description: |-
+                      SecretRef holds the name of a secret that contains a key with
+                      the kubeconfig file as the value. If no key is set, the key will default
+                      to 'value'.
+                      It is recommended that the kubeconfig is self-contained, and the secret
+                      is regularly updated if credentials such as a cloud-access-token expire.
+                      Cloud specific `cmd-path` auth helpers will not function without adding
+                      binaries and credentials to the Pod that is responsible for reconciling
+                      Kubernetes resources.
+                    properties:
+                      key:
+                        description: Key in the Secret, when not specified an implementation-specific
+                          default key is used.
+                        type: string
+                      name:
+                        description: Name of the Secret.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - secretRef
+                type: object
+              maxHistory:
+                description: |-
+                  MaxHistory is the number of revisions saved by Helm for this HelmRelease.
+                  Use '0' for an unlimited number of revisions; defaults to '5'.
+                type: integer
+              persistentClient:
+                description: |-
+                  PersistentClient tells the controller to use a persistent Kubernetes
+                  client for this release. When enabled, the client will be reused for the
+                  duration of the reconciliation, instead of being created and destroyed
+                  for each (step of a) Helm action.
+
+
+                  This can improve performance, but may cause issues with some Helm charts
+                  that for example do create Custom Resource Definitions during installation
+                  outside Helm's CRD lifecycle hooks, which are then not observed to be
+                  available by e.g. post-install hooks.
+
+
+                  If not set, it defaults to true.
+                type: boolean
+              postRenderers:
+                description: |-
+                  PostRenderers holds an array of Helm PostRenderers, which will be applied in order
+                  of their definition.
+                items:
+                  description: PostRenderer contains a Helm PostRenderer specification.
+                  properties:
+                    kustomize:
+                      description: Kustomization to apply as PostRenderer.
+                      properties:
+                        images:
+                          description: |-
+                            Images is a list of (image name, new name, new tag or digest)
+                            for changing image names, tags or digests. This can also be achieved with a
+                            patch, but this operator is simpler to specify.
+                          items:
+                            description: Image contains an image name, a new name,
+                              a new tag or digest, which will replace the original
+                              name and tag.
+                            properties:
+                              digest:
+                                description: |-
+                                  Digest is the value used to replace the original image tag.
+                                  If digest is present NewTag value is ignored.
+                                type: string
+                              name:
+                                description: Name is a tag-less image name.
+                                type: string
+                              newName:
+                                description: NewName is the value used to replace
+                                  the original name.
+                                type: string
+                              newTag:
+                                description: NewTag is the value used to replace the
+                                  original tag.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        patches:
+                          description: |-
+                            Strategic merge and JSON patches, defined as inline YAML objects,
+                            capable of targeting objects based on kind, label and annotation selectors.
+                          items:
+                            description: |-
+                              Patch contains an inline StrategicMerge or JSON6902 patch, and the target the patch should
+                              be applied to.
+                            properties:
+                              patch:
+                                description: |-
+                                  Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with
+                                  an array of operation objects.
+                                type: string
+                              target:
+                                description: Target points to the resources that the
+                                  patch document should be applied to.
+                                properties:
+                                  annotationSelector:
+                                    description: |-
+                                      AnnotationSelector is a string that follows the label selection expression
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                      It matches with the resource annotations.
+                                    type: string
+                                  group:
+                                    description: |-
+                                      Group is the API group to select resources from.
+                                      Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                    type: string
+                                  kind:
+                                    description: |-
+                                      Kind of the API Group to select resources from.
+                                      Together with Group and Version it is capable of unambiguously
+                                      identifying and/or selecting resources.
+                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                    type: string
+                                  labelSelector:
+                                    description: |-
+                                      LabelSelector is a string that follows the label selection expression
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                      It matches with the resource labels.
+                                    type: string
+                                  name:
+                                    description: Name to match resources with.
+                                    type: string
+                                  namespace:
+                                    description: Namespace to select resources from.
+                                    type: string
+                                  version:
+                                    description: |-
+                                      Version of the API Group to select resources from.
+                                      Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                    type: string
+                                type: object
+                            required:
+                            - patch
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+                type: array
+              releaseName:
+                description: |-
+                  ReleaseName used for the Helm release. Defaults to a composition of
+                  '[TargetNamespace-]Name'.
+                maxLength: 53
+                minLength: 1
+                type: string
+              rollback:
+                description: Rollback holds the configuration for Helm rollback actions
+                  for this HelmRelease.
+                properties:
+                  cleanupOnFail:
+                    description: |-
+                      CleanupOnFail allows deletion of new resources created during the Helm
+                      rollback action when it fails.
+                    type: boolean
+                  disableHooks:
+                    description: DisableHooks prevents hooks from running during the
+                      Helm rollback action.
+                    type: boolean
+                  disableWait:
+                    description: |-
+                      DisableWait disables the waiting for resources to be ready after a Helm
+                      rollback has been performed.
+                    type: boolean
+                  disableWaitForJobs:
+                    description: |-
+                      DisableWaitForJobs disables waiting for jobs to complete after a Helm
+                      rollback has been performed.
+                    type: boolean
+                  force:
+                    description: Force forces resource updates through a replacement
+                      strategy.
+                    type: boolean
+                  recreate:
+                    description: Recreate performs pod restarts for the resource if
+                      applicable.
+                    type: boolean
+                  timeout:
+                    description: |-
+                      Timeout is the time to wait for any individual Kubernetes operation (like
+                      Jobs for hooks) during the performance of a Helm rollback action. Defaults to
+                      'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              serviceAccountName:
+                description: |-
+                  The name of the Kubernetes service account to impersonate
+                  when reconciling this HelmRelease.
+                maxLength: 253
+                minLength: 1
+                type: string
+              storageNamespace:
+                description: |-
+                  StorageNamespace used for the Helm storage.
+                  Defaults to the namespace of the HelmRelease.
+                maxLength: 63
+                minLength: 1
+                type: string
+              suspend:
+                description: |-
+                  Suspend tells the controller to suspend reconciliation for this HelmRelease,
+                  it does not apply to already started reconciliations. Defaults to false.
+                type: boolean
+              targetNamespace:
+                description: |-
+                  TargetNamespace to target when performing operations for the HelmRelease.
+                  Defaults to the namespace of the HelmRelease.
+                maxLength: 63
+                minLength: 1
+                type: string
+              test:
+                description: Test holds the configuration for Helm test actions for
+                  this HelmRelease.
+                properties:
+                  enable:
+                    description: |-
+                      Enable enables Helm test actions for this HelmRelease after an Helm install
+                      or upgrade action has been performed.
+                    type: boolean
+                  filters:
+                    description: Filters is a list of tests to run or exclude from
+                      running.
+                    items:
+                      description: Filter holds the configuration for individual Helm
+                        test filters.
+                      properties:
+                        exclude:
+                          description: Exclude specifies whether the named test should
+                            be excluded.
+                          type: boolean
+                        name:
+                          description: Name is the name of the test.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  ignoreFailures:
+                    description: |-
+                      IgnoreFailures tells the controller to skip remediation when the Helm tests
+                      are run but fail. Can be overwritten for tests run after install or upgrade
+                      actions in 'Install.IgnoreTestFailures' and 'Upgrade.IgnoreTestFailures'.
+                    type: boolean
+                  timeout:
+                    description: |-
+                      Timeout is the time to wait for any individual Kubernetes operation during
+                      the performance of a Helm test action. Defaults to 'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              timeout:
+                description: |-
+                  Timeout is the time to wait for any individual Kubernetes operation (like Jobs
+                  for hooks) during the performance of a Helm action. Defaults to '5m0s'.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              uninstall:
+                description: Uninstall holds the configuration for Helm uninstall
+                  actions for this HelmRelease.
+                properties:
+                  deletionPropagation:
+                    default: background
+                    description: |-
+                      DeletionPropagation specifies the deletion propagation policy when
+                      a Helm uninstall is performed.
+                    enum:
+                    - background
+                    - foreground
+                    - orphan
+                    type: string
+                  disableHooks:
+                    description: DisableHooks prevents hooks from running during the
+                      Helm rollback action.
+                    type: boolean
+                  disableWait:
+                    description: |-
+                      DisableWait disables waiting for all the resources to be deleted after
+                      a Helm uninstall is performed.
+                    type: boolean
+                  keepHistory:
+                    description: |-
+                      KeepHistory tells Helm to remove all associated resources and mark the
+                      release as deleted, but retain the release history.
+                    type: boolean
+                  timeout:
+                    description: |-
+                      Timeout is the time to wait for any individual Kubernetes operation (like
+                      Jobs for hooks) during the performance of a Helm uninstall action. Defaults
+                      to 'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              upgrade:
+                description: Upgrade holds the configuration for Helm upgrade actions
+                  for this HelmRelease.
+                properties:
+                  cleanupOnFail:
+                    description: |-
+                      CleanupOnFail allows deletion of new resources created during the Helm
+                      upgrade action when it fails.
+                    type: boolean
+                  crds:
+                    description: |-
+                      CRDs upgrade CRDs from the Helm Chart's crds directory according
+                      to the CRD upgrade policy provided here. Valid values are `Skip`,
+                      `Create` or `CreateReplace`. Default is `Skip` and if omitted
+                      CRDs are neither installed nor upgraded.
+
+
+                      Skip: do neither install nor replace (update) any CRDs.
+
+
+                      Create: new CRDs are created, existing CRDs are neither updated nor deleted.
+
+
+                      CreateReplace: new CRDs are created, existing CRDs are updated (replaced)
+                      but not deleted.
+
+
+                      By default, CRDs are not applied during Helm upgrade action. With this
+                      option users can opt-in to CRD upgrade, which is not (yet) natively supported by Helm.
+                      https://helm.sh/docs/chart_best_practices/custom_resource_definitions.
+                    enum:
+                    - Skip
+                    - Create
+                    - CreateReplace
+                    type: string
+                  disableHooks:
+                    description: DisableHooks prevents hooks from running during the
+                      Helm upgrade action.
+                    type: boolean
+                  disableOpenAPIValidation:
+                    description: |-
+                      DisableOpenAPIValidation prevents the Helm upgrade action from validating
+                      rendered templates against the Kubernetes OpenAPI Schema.
+                    type: boolean
+                  disableWait:
+                    description: |-
+                      DisableWait disables the waiting for resources to be ready after a Helm
+                      upgrade has been performed.
+                    type: boolean
+                  disableWaitForJobs:
+                    description: |-
+                      DisableWaitForJobs disables waiting for jobs to complete after a Helm
+                      upgrade has been performed.
+                    type: boolean
+                  force:
+                    description: Force forces resource updates through a replacement
+                      strategy.
+                    type: boolean
+                  preserveValues:
+                    description: |-
+                      PreserveValues will make Helm reuse the last release's values and merge in
+                      overrides from 'Values'. Setting this flag makes the HelmRelease
+                      non-declarative.
+                    type: boolean
+                  remediation:
+                    description: |-
+                      Remediation holds the remediation configuration for when the Helm upgrade
+                      action for the HelmRelease fails. The default is to not perform any action.
+                    properties:
+                      ignoreTestFailures:
+                        description: |-
+                          IgnoreTestFailures tells the controller to skip remediation when the Helm
+                          tests are run after an upgrade action but fail.
+                          Defaults to 'Test.IgnoreFailures'.
+                        type: boolean
+                      remediateLastFailure:
+                        description: |-
+                          RemediateLastFailure tells the controller to remediate the last failure, when
+                          no retries remain. Defaults to 'false' unless 'Retries' is greater than 0.
+                        type: boolean
+                      retries:
+                        description: |-
+                          Retries is the number of retries that should be attempted on failures before
+                          bailing. Remediation, using 'Strategy', is performed between each attempt.
+                          Defaults to '0', a negative integer equals to unlimited retries.
+                        type: integer
+                      strategy:
+                        description: Strategy to use for failure remediation. Defaults
+                          to 'rollback'.
+                        enum:
+                        - rollback
+                        - uninstall
+                        type: string
+                    type: object
+                  timeout:
+                    description: |-
+                      Timeout is the time to wait for any individual Kubernetes operation (like
+                      Jobs for hooks) during the performance of a Helm upgrade action. Defaults to
+                      'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              values:
+                description: Values holds the values for this Helm release.
+                x-kubernetes-preserve-unknown-fields: true
+              valuesFrom:
+                description: |-
+                  ValuesFrom holds references to resources containing Helm values for this HelmRelease,
+                  and information about how they should be merged.
+                items:
+                  description: |-
+                    ValuesReference contains a reference to a resource containing Helm values,
+                    and optionally the key they can be found at.
+                  properties:
+                    kind:
+                      description: Kind of the values referent, valid values are ('Secret',
+                        'ConfigMap').
+                      enum:
+                      - Secret
+                      - ConfigMap
+                      type: string
+                    name:
+                      description: |-
+                        Name of the values referent. Should reside in the same namespace as the
+                        referring resource.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    optional:
+                      description: |-
+                        Optional marks this ValuesReference as optional. When set, a not found error
+                        for the values reference is ignored, but any ValuesKey, TargetPath or
+                        transient error will still result in a reconciliation failure.
+                      type: boolean
+                    targetPath:
+                      description: |-
+                        TargetPath is the YAML dot notation path the value should be merged at. When
+                        set, the ValuesKey is expected to be a single flat value. Defaults to 'None',
+                        which results in the values getting merged at the root.
+                      maxLength: 250
+                      pattern: ^([a-zA-Z0-9_\-.\\\/]|\[[0-9]{1,5}\])+$
+                      type: string
+                    valuesKey:
+                      description: |-
+                        ValuesKey is the data key where the values.yaml or a specific value can be
+                        found at. Defaults to 'values.yaml'.
+                      maxLength: 253
+                      pattern: ^[\-._a-zA-Z0-9]+$
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                type: array
+            required:
+            - interval
+            type: object
+            x-kubernetes-validations:
+            - message: either chart or chartRef must be set
+              rule: (has(self.chart) && !has(self.chartRef)) || (!has(self.chart)
+                && has(self.chartRef))
+          status:
+            default:
+              observedGeneration: -1
+            description: HelmReleaseStatus defines the observed state of a HelmRelease.
+            properties:
+              conditions:
+                description: Conditions holds the conditions for the HelmRelease.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              failures:
+                description: |-
+                  Failures is the reconciliation failure count against the latest desired
+                  state. It is reset after a successful reconciliation.
+                format: int64
+                type: integer
+              helmChart:
+                description: |-
+                  HelmChart is the namespaced name of the HelmChart resource created by
+                  the controller for the HelmRelease.
+                type: string
+              history:
+                description: |-
+                  History holds the history of Helm releases performed for this HelmRelease
+                  up to the last successfully completed release.
+                items:
+                  description: |-
+                    Snapshot captures a point-in-time copy of the status information for a Helm release,
+                    as managed by the controller.
+                  properties:
+                    apiVersion:
+                      description: |-
+                        APIVersion is the API version of the Snapshot.
+                        Provisional: when the calculation method of the Digest field is changed,
+                        this field will be used to distinguish between the old and new methods.
+                      type: string
+                    appVersion:
+                      description: AppVersion is the chart app version of the release
+                        object in storage.
+                      type: string
+                    chartName:
+                      description: ChartName is the chart name of the release object
+                        in storage.
+                      type: string
+                    chartVersion:
+                      description: |-
+                        ChartVersion is the chart version of the release object in
+                        storage.
+                      type: string
+                    configDigest:
+                      description: |-
+                        ConfigDigest is the checksum of the config (better known as
+                        "values") of the release object in storage.
+                        It has the format of `<algo>:<checksum>`.
+                      type: string
+                    deleted:
+                      description: Deleted is when the release was deleted.
+                      format: date-time
+                      type: string
+                    digest:
+                      description: |-
+                        Digest is the checksum of the release object in storage.
+                        It has the format of `<algo>:<checksum>`.
+                      type: string
+                    firstDeployed:
+                      description: FirstDeployed is when the release was first deployed.
+                      format: date-time
+                      type: string
+                    lastDeployed:
+                      description: LastDeployed is when the release was last deployed.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the release.
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace the release is deployed
+                        to.
+                      type: string
+                    ociDigest:
+                      description: OCIDigest is the digest of the OCI artifact associated
+                        with the release.
+                      type: string
+                    status:
+                      description: Status is the current state of the release.
+                      type: string
+                    testHooks:
+                      additionalProperties:
+                        description: |-
+                          TestHookStatus holds the status information for a test hook as observed
+                          to be run by the controller.
+                        properties:
+                          lastCompleted:
+                            description: LastCompleted is the time the test hook last
+                              completed.
+                            format: date-time
+                            type: string
+                          lastStarted:
+                            description: LastStarted is the time the test hook was
+                              last started.
+                            format: date-time
+                            type: string
+                          phase:
+                            description: Phase the test hook was observed to be in.
+                            type: string
+                        type: object
+                      description: |-
+                        TestHooks is the list of test hooks for the release as observed to be
+                        run by the controller.
+                      type: object
+                    version:
+                      description: Version is the version of the release object in
+                        storage.
+                      type: integer
+                  required:
+                  - chartName
+                  - chartVersion
+                  - configDigest
+                  - digest
+                  - firstDeployed
+                  - lastDeployed
+                  - name
+                  - namespace
+                  - status
+                  - version
+                  type: object
+                type: array
+              installFailures:
+                description: |-
+                  InstallFailures is the install failure count against the latest desired
+                  state. It is reset after a successful reconciliation.
+                format: int64
+                type: integer
+              lastAttemptedConfigDigest:
+                description: |-
+                  LastAttemptedConfigDigest is the digest for the config (better known as
+                  "values") of the last reconciliation attempt.
+                type: string
+              lastAttemptedGeneration:
+                description: |-
+                  LastAttemptedGeneration is the last generation the controller attempted
+                  to reconcile.
+                format: int64
+                type: integer
+              lastAttemptedReleaseAction:
+                description: |-
+                  LastAttemptedReleaseAction is the last release action performed for this
+                  HelmRelease. It is used to determine the active remediation strategy.
+                enum:
+                - install
+                - upgrade
+                type: string
+              lastAttemptedRevision:
+                description: |-
+                  LastAttemptedRevision is the Source revision of the last reconciliation
+                  attempt. For OCIRepository  sources, the 12 first characters of the digest are
+                  appended to the chart version e.g. "1.2.3+1234567890ab".
+                type: string
+              lastAttemptedRevisionDigest:
+                description: |-
+                  LastAttemptedRevisionDigest is the digest of the last reconciliation attempt.
+                  This is only set for OCIRepository sources.
+                type: string
+              lastAttemptedValuesChecksum:
+                description: |-
+                  LastAttemptedValuesChecksum is the SHA1 checksum for the values of the last
+                  reconciliation attempt.
+                  Deprecated: Use LastAttemptedConfigDigest instead.
+                type: string
+              lastHandledForceAt:
+                description: |-
+                  LastHandledForceAt holds the value of the most recent force request
+                  value, so a change of the annotation value can be detected.
+                type: string
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              lastHandledResetAt:
+                description: |-
+                  LastHandledResetAt holds the value of the most recent reset request
+                  value, so a change of the annotation value can be detected.
+                type: string
+              lastReleaseRevision:
+                description: |-
+                  LastReleaseRevision is the revision of the last successful Helm release.
+                  Deprecated: Use History instead.
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation.
+                format: int64
+                type: integer
+              observedPostRenderersDigest:
+                description: |-
+                  ObservedPostRenderersDigest is the digest for the post-renderers of
+                  the last successful reconciliation attempt.
+                type: string
+              storageNamespace:
+                description: |-
+                  StorageNamespace is the namespace of the Helm release storage for the
+                  current release.
+                maxLength: 63
+                minLength: 1
+                type: string
+              upgradeFailures:
+                description: |-
+                  UpgradeFailures is the upgrade failure count against the latest desired
+                  state. It is reset after a successful reconciliation.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    deprecated: true
+    deprecationWarning: v2beta1 HelmRelease is deprecated, upgrade to v2
+    name: v2beta1
+    schema:
+      openAPIV3Schema:
+        description: HelmRelease is the Schema for the helmreleases API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HelmReleaseSpec defines the desired state of a Helm release.
+            properties:
+              chart:
+                description: |-
+                  Chart defines the template of the v1beta2.HelmChart that should be created
+                  for this HelmRelease.
+                properties:
+                  metadata:
+                    description: ObjectMeta holds the template for metadata like labels
+                      and annotations.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+                        type: object
+                    type: object
+                  spec:
+                    description: Spec holds the template for the v1beta2.HelmChartSpec
+                      for this HelmRelease.
+                    properties:
+                      chart:
+                        description: The name or path the Helm chart is available
+                          at in the SourceRef.
+                        type: string
+                      interval:
+                        description: |-
+                          Interval at which to check the v1beta2.Source for updates. Defaults to
+                          'HelmReleaseSpec.Interval'.
+                        pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                        type: string
+                      reconcileStrategy:
+                        default: ChartVersion
+                        description: |-
+                          Determines what enables the creation of a new artifact. Valid values are
+                          ('ChartVersion', 'Revision').
+                          See the documentation of the values for an explanation on their behavior.
+                          Defaults to ChartVersion when omitted.
+                        enum:
+                        - ChartVersion
+                        - Revision
+                        type: string
+                      sourceRef:
+                        description: The name and namespace of the v1beta2.Source
+                          the chart is available at.
+                        properties:
+                          apiVersion:
+                            description: APIVersion of the referent.
+                            type: string
+                          kind:
+                            description: Kind of the referent.
+                            enum:
+                            - HelmRepository
+                            - GitRepository
+                            - Bucket
+                            type: string
+                          name:
+                            description: Name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: Namespace of the referent.
+                            maxLength: 63
+                            minLength: 1
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      valuesFile:
+                        description: |-
+                          Alternative values file to use as the default chart values, expected to
+                          be a relative path in the SourceRef. Deprecated in favor of ValuesFiles,
+                          for backwards compatibility the file defined here is merged before the
+                          ValuesFiles items. Ignored when omitted.
+                        type: string
+                      valuesFiles:
+                        description: |-
+                          Alternative list of values files to use as the chart values (values.yaml
+                          is not included by default), expected to be a relative path in the SourceRef.
+                          Values files are merged in the order of this list with the last file overriding
+                          the first. Ignored when omitted.
+                        items:
+                          type: string
+                        type: array
+                      verify:
+                        description: |-
+                          Verify contains the secret name containing the trusted public keys
+                          used to verify the signature and specifies which provider to use to check
+                          whether OCI image is authentic.
+                          This field is only supported for OCI sources.
+                          Chart dependencies, which are not bundled in the umbrella chart artifact, are not verified.
+                        properties:
+                          provider:
+                            default: cosign
+                            description: Provider specifies the technology used to
+                              sign the OCI Helm chart.
+                            enum:
+                            - cosign
+                            type: string
+                          secretRef:
+                            description: |-
+                              SecretRef specifies the Kubernetes Secret containing the
+                              trusted public keys.
+                            properties:
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                        required:
+                        - provider
+                        type: object
+                      version:
+                        default: '*'
+                        description: |-
+                          Version semver expression, ignored for charts from v1beta2.GitRepository and
+                          v1beta2.Bucket sources. Defaults to latest when omitted.
+                        type: string
+                    required:
+                    - chart
+                    - sourceRef
+                    type: object
+                required:
+                - spec
+                type: object
+              chartRef:
+                description: |-
+                  ChartRef holds a reference to a source controller resource containing the
+                  Helm chart artifact.
+
+
+                  Note: this field is provisional to the v2 API, and not actively used
+                  by v2beta1 HelmReleases.
+                properties:
+                  apiVersion:
+                    description: APIVersion of the referent.
+                    type: string
+                  kind:
+                    description: Kind of the referent.
+                    enum:
+                    - OCIRepository
+                    - HelmChart
+                    type: string
+                  name:
+                    description: Name of the referent.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent, defaults to the namespace of the Kubernetes
+                      resource object that contains the reference.
+                    maxLength: 63
+                    minLength: 1
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              dependsOn:
+                description: |-
+                  DependsOn may contain a meta.NamespacedObjectReference slice with
+                  references to HelmRelease resources that must be ready before this HelmRelease
+                  can be reconciled.
+                items:
+                  description: |-
+                    NamespacedObjectReference contains enough information to locate the referenced Kubernetes resource object in any
+                    namespace.
+                  properties:
+                    name:
+                      description: Name of the referent.
+                      type: string
+                    namespace:
+                      description: Namespace of the referent, when not specified it
+                        acts as LocalObjectReference.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              driftDetection:
+                description: |-
+                  DriftDetection holds the configuration for detecting and handling
+                  differences between the manifest in the Helm storage and the resources
+                  currently existing in the cluster.
+
+
+                  Note: this field is provisional to the v2beta2 API, and not actively used
+                  by v2beta1 HelmReleases.
+                properties:
+                  ignore:
+                    description: |-
+                      Ignore contains a list of rules for specifying which changes to ignore
+                      during diffing.
+                    items:
+                      description: |-
+                        IgnoreRule defines a rule to selectively disregard specific changes during
+                        the drift detection process.
+                      properties:
+                        paths:
+                          description: |-
+                            Paths is a list of JSON Pointer (RFC 6901) paths to be excluded from
+                            consideration in a Kubernetes object.
+                          items:
+                            type: string
+                          type: array
+                        target:
+                          description: |-
+                            Target is a selector for specifying Kubernetes objects to which this
+                            rule applies.
+                            If Target is not set, the Paths will be ignored for all Kubernetes
+                            objects within the manifest of the Helm release.
+                          properties:
+                            annotationSelector:
+                              description: |-
+                                AnnotationSelector is a string that follows the label selection expression
+                                https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                It matches with the resource annotations.
+                              type: string
+                            group:
+                              description: |-
+                                Group is the API group to select resources from.
+                                Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                              type: string
+                            kind:
+                              description: |-
+                                Kind of the API Group to select resources from.
+                                Together with Group and Version it is capable of unambiguously
+                                identifying and/or selecting resources.
+                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                              type: string
+                            labelSelector:
+                              description: |-
+                                LabelSelector is a string that follows the label selection expression
+                                https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                It matches with the resource labels.
+                              type: string
+                            name:
+                              description: Name to match resources with.
+                              type: string
+                            namespace:
+                              description: Namespace to select resources from.
+                              type: string
+                            version:
+                              description: |-
+                                Version of the API Group to select resources from.
+                                Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                              type: string
+                          type: object
+                      required:
+                      - paths
+                      type: object
+                    type: array
+                  mode:
+                    description: |-
+                      Mode defines how differences should be handled between the Helm manifest
+                      and the manifest currently applied to the cluster.
+                      If not explicitly set, it defaults to DiffModeDisabled.
+                    enum:
+                    - enabled
+                    - warn
+                    - disabled
+                    type: string
+                type: object
+              install:
+                description: Install holds the configuration for Helm install actions
+                  for this HelmRelease.
+                properties:
+                  crds:
+                    description: |-
+                      CRDs upgrade CRDs from the Helm Chart's crds directory according
+                      to the CRD upgrade policy provided here. Valid values are `Skip`,
+                      `Create` or `CreateReplace`. Default is `Create` and if omitted
+                      CRDs are installed but not updated.
+
+
+                      Skip: do neither install nor replace (update) any CRDs.
+
+
+                      Create: new CRDs are created, existing CRDs are neither updated nor deleted.
+
+
+                      CreateReplace: new CRDs are created, existing CRDs are updated (replaced)
+                      but not deleted.
+
+
+                      By default, CRDs are applied (installed) during Helm install action.
+                      With this option users can opt-in to CRD replace existing CRDs on Helm
+                      install actions, which is not (yet) natively supported by Helm.
+                      https://helm.sh/docs/chart_best_practices/custom_resource_definitions.
+                    enum:
+                    - Skip
+                    - Create
+                    - CreateReplace
+                    type: string
+                  createNamespace:
+                    description: |-
+                      CreateNamespace tells the Helm install action to create the
+                      HelmReleaseSpec.TargetNamespace if it does not exist yet.
+                      On uninstall, the namespace will not be garbage collected.
+                    type: boolean
+                  disableHooks:
+                    description: DisableHooks prevents hooks from running during the
+                      Helm install action.
+                    type: boolean
+                  disableOpenAPIValidation:
+                    description: |-
+                      DisableOpenAPIValidation prevents the Helm install action from validating
+                      rendered templates against the Kubernetes OpenAPI Schema.
+                    type: boolean
+                  disableWait:
+                    description: |-
+                      DisableWait disables the waiting for resources to be ready after a Helm
+                      install has been performed.
+                    type: boolean
+                  disableWaitForJobs:
+                    description: |-
+                      DisableWaitForJobs disables waiting for jobs to complete after a Helm
+                      install has been performed.
+                    type: boolean
+                  remediation:
+                    description: |-
+                      Remediation holds the remediation configuration for when the Helm install
+                      action for the HelmRelease fails. The default is to not perform any action.
+                    properties:
+                      ignoreTestFailures:
+                        description: |-
+                          IgnoreTestFailures tells the controller to skip remediation when the Helm
+                          tests are run after an install action but fail. Defaults to
+                          'Test.IgnoreFailures'.
+                        type: boolean
+                      remediateLastFailure:
+                        description: |-
+                          RemediateLastFailure tells the controller to remediate the last failure, when
+                          no retries remain. Defaults to 'false'.
+                        type: boolean
+                      retries:
+                        description: |-
+                          Retries is the number of retries that should be attempted on failures before
+                          bailing. Remediation, using an uninstall, is performed between each attempt.
+                          Defaults to '0', a negative integer equals to unlimited retries.
+                        type: integer
+                    type: object
+                  replace:
+                    description: |-
+                      Replace tells the Helm install action to re-use the 'ReleaseName', but only
+                      if that name is a deleted release which remains in the history.
+                    type: boolean
+                  skipCRDs:
+                    description: |-
+                      SkipCRDs tells the Helm install action to not install any CRDs. By default,
+                      CRDs are installed if not already present.
+
+
+                      Deprecated use CRD policy (`crds`) attribute with value `Skip` instead.
+                    type: boolean
+                  timeout:
+                    description: |-
+                      Timeout is the time to wait for any individual Kubernetes operation (like
+                      Jobs for hooks) during the performance of a Helm install action. Defaults to
+                      'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              interval:
+                description: |-
+                  Interval at which to reconcile the Helm release.
+                  This interval is approximate and may be subject to jitter to ensure
+                  efficient use of resources.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              kubeConfig:
+                description: |-
+                  KubeConfig for reconciling the HelmRelease on a remote cluster.
+                  When used in combination with HelmReleaseSpec.ServiceAccountName,
+                  forces the controller to act on behalf of that Service Account at the
+                  target cluster.
+                  If the --default-service-account flag is set, its value will be used as
+                  a controller level fallback for when HelmReleaseSpec.ServiceAccountName
+                  is empty.
+                properties:
+                  secretRef:
+                    description: |-
+                      SecretRef holds the name of a secret that contains a key with
+                      the kubeconfig file as the value. If no key is set, the key will default
+                      to 'value'.
+                      It is recommended that the kubeconfig is self-contained, and the secret
+                      is regularly updated if credentials such as a cloud-access-token expire.
+                      Cloud specific `cmd-path` auth helpers will not function without adding
+                      binaries and credentials to the Pod that is responsible for reconciling
+                      Kubernetes resources.
+                    properties:
+                      key:
+                        description: Key in the Secret, when not specified an implementation-specific
+                          default key is used.
+                        type: string
+                      name:
+                        description: Name of the Secret.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - secretRef
+                type: object
+              maxHistory:
+                description: |-
+                  MaxHistory is the number of revisions saved by Helm for this HelmRelease.
+                  Use '0' for an unlimited number of revisions; defaults to '10'.
+                type: integer
+              persistentClient:
+                description: |-
+                  PersistentClient tells the controller to use a persistent Kubernetes
+                  client for this release. When enabled, the client will be reused for the
+                  duration of the reconciliation, instead of being created and destroyed
+                  for each (step of a) Helm action.
+
+
+                  This can improve performance, but may cause issues with some Helm charts
+                  that for example do create Custom Resource Definitions during installation
+                  outside Helm's CRD lifecycle hooks, which are then not observed to be
+                  available by e.g. post-install hooks.
+
+
+                  If not set, it defaults to true.
+                type: boolean
+              postRenderers:
+                description: |-
+                  PostRenderers holds an array of Helm PostRenderers, which will be applied in order
+                  of their definition.
+                items:
+                  description: PostRenderer contains a Helm PostRenderer specification.
+                  properties:
+                    kustomize:
+                      description: Kustomization to apply as PostRenderer.
+                      properties:
+                        images:
+                          description: |-
+                            Images is a list of (image name, new name, new tag or digest)
+                            for changing image names, tags or digests. This can also be achieved with a
+                            patch, but this operator is simpler to specify.
+                          items:
+                            description: Image contains an image name, a new name,
+                              a new tag or digest, which will replace the original
+                              name and tag.
+                            properties:
+                              digest:
+                                description: |-
+                                  Digest is the value used to replace the original image tag.
+                                  If digest is present NewTag value is ignored.
+                                type: string
+                              name:
+                                description: Name is a tag-less image name.
+                                type: string
+                              newName:
+                                description: NewName is the value used to replace
+                                  the original name.
+                                type: string
+                              newTag:
+                                description: NewTag is the value used to replace the
+                                  original tag.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        patches:
+                          description: |-
+                            Strategic merge and JSON patches, defined as inline YAML objects,
+                            capable of targeting objects based on kind, label and annotation selectors.
+                          items:
+                            description: |-
+                              Patch contains an inline StrategicMerge or JSON6902 patch, and the target the patch should
+                              be applied to.
+                            properties:
+                              patch:
+                                description: |-
+                                  Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with
+                                  an array of operation objects.
+                                type: string
+                              target:
+                                description: Target points to the resources that the
+                                  patch document should be applied to.
+                                properties:
+                                  annotationSelector:
+                                    description: |-
+                                      AnnotationSelector is a string that follows the label selection expression
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                      It matches with the resource annotations.
+                                    type: string
+                                  group:
+                                    description: |-
+                                      Group is the API group to select resources from.
+                                      Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                    type: string
+                                  kind:
+                                    description: |-
+                                      Kind of the API Group to select resources from.
+                                      Together with Group and Version it is capable of unambiguously
+                                      identifying and/or selecting resources.
+                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                    type: string
+                                  labelSelector:
+                                    description: |-
+                                      LabelSelector is a string that follows the label selection expression
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                      It matches with the resource labels.
+                                    type: string
+                                  name:
+                                    description: Name to match resources with.
+                                    type: string
+                                  namespace:
+                                    description: Namespace to select resources from.
+                                    type: string
+                                  version:
+                                    description: |-
+                                      Version of the API Group to select resources from.
+                                      Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                    type: string
+                                type: object
+                            required:
+                            - patch
+                            type: object
+                          type: array
+                        patchesJson6902:
+                          description: JSON 6902 patches, defined as inline YAML objects.
+                          items:
+                            description: JSON6902Patch contains a JSON6902 patch and
+                              the target the patch should be applied to.
+                            properties:
+                              patch:
+                                description: Patch contains the JSON6902 patch document
+                                  with an array of operation objects.
+                                items:
+                                  description: |-
+                                    JSON6902 is a JSON6902 operation object.
+                                    https://datatracker.ietf.org/doc/html/rfc6902#section-4
+                                  properties:
+                                    from:
+                                      description: |-
+                                        From contains a JSON-pointer value that references a location within the target document where the operation is
+                                        performed. The meaning of the value depends on the value of Op, and is NOT taken into account by all operations.
+                                      type: string
+                                    op:
+                                      description: |-
+                                        Op indicates the operation to perform. Its value MUST be one of "add", "remove", "replace", "move", "copy", or
+                                        "test".
+                                        https://datatracker.ietf.org/doc/html/rfc6902#section-4
+                                      enum:
+                                      - test
+                                      - remove
+                                      - add
+                                      - replace
+                                      - move
+                                      - copy
+                                      type: string
+                                    path:
+                                      description: |-
+                                        Path contains the JSON-pointer value that references a location within the target document where the operation
+                                        is performed. The meaning of the value depends on the value of Op.
+                                      type: string
+                                    value:
+                                      description: |-
+                                        Value contains a valid JSON structure. The meaning of the value depends on the value of Op, and is NOT taken into
+                                        account by all operations.
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  required:
+                                  - op
+                                  - path
+                                  type: object
+                                type: array
+                              target:
+                                description: Target points to the resources that the
+                                  patch document should be applied to.
+                                properties:
+                                  annotationSelector:
+                                    description: |-
+                                      AnnotationSelector is a string that follows the label selection expression
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                      It matches with the resource annotations.
+                                    type: string
+                                  group:
+                                    description: |-
+                                      Group is the API group to select resources from.
+                                      Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                    type: string
+                                  kind:
+                                    description: |-
+                                      Kind of the API Group to select resources from.
+                                      Together with Group and Version it is capable of unambiguously
+                                      identifying and/or selecting resources.
+                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                    type: string
+                                  labelSelector:
+                                    description: |-
+                                      LabelSelector is a string that follows the label selection expression
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                      It matches with the resource labels.
+                                    type: string
+                                  name:
+                                    description: Name to match resources with.
+                                    type: string
+                                  namespace:
+                                    description: Namespace to select resources from.
+                                    type: string
+                                  version:
+                                    description: |-
+                                      Version of the API Group to select resources from.
+                                      Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                    type: string
+                                type: object
+                            required:
+                            - patch
+                            - target
+                            type: object
+                          type: array
+                        patchesStrategicMerge:
+                          description: Strategic merge patches, defined as inline
+                            YAML objects.
+                          items:
+                            x-kubernetes-preserve-unknown-fields: true
+                          type: array
+                      type: object
+                  type: object
+                type: array
+              releaseName:
+                description: |-
+                  ReleaseName used for the Helm release. Defaults to a composition of
+                  '[TargetNamespace-]Name'.
+                maxLength: 53
+                minLength: 1
+                type: string
+              rollback:
+                description: Rollback holds the configuration for Helm rollback actions
+                  for this HelmRelease.
+                properties:
+                  cleanupOnFail:
+                    description: |-
+                      CleanupOnFail allows deletion of new resources created during the Helm
+                      rollback action when it fails.
+                    type: boolean
+                  disableHooks:
+                    description: DisableHooks prevents hooks from running during the
+                      Helm rollback action.
+                    type: boolean
+                  disableWait:
+                    description: |-
+                      DisableWait disables the waiting for resources to be ready after a Helm
+                      rollback has been performed.
+                    type: boolean
+                  disableWaitForJobs:
+                    description: |-
+                      DisableWaitForJobs disables waiting for jobs to complete after a Helm
+                      rollback has been performed.
+                    type: boolean
+                  force:
+                    description: Force forces resource updates through a replacement
+                      strategy.
+                    type: boolean
+                  recreate:
+                    description: Recreate performs pod restarts for the resource if
+                      applicable.
+                    type: boolean
+                  timeout:
+                    description: |-
+                      Timeout is the time to wait for any individual Kubernetes operation (like
+                      Jobs for hooks) during the performance of a Helm rollback action. Defaults to
+                      'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              serviceAccountName:
+                description: |-
+                  The name of the Kubernetes service account to impersonate
+                  when reconciling this HelmRelease.
+                type: string
+              storageNamespace:
+                description: |-
+                  StorageNamespace used for the Helm storage.
+                  Defaults to the namespace of the HelmRelease.
+                maxLength: 63
+                minLength: 1
+                type: string
+              suspend:
+                description: |-
+                  Suspend tells the controller to suspend reconciliation for this HelmRelease,
+                  it does not apply to already started reconciliations. Defaults to false.
+                type: boolean
+              targetNamespace:
+                description: |-
+                  TargetNamespace to target when performing operations for the HelmRelease.
+                  Defaults to the namespace of the HelmRelease.
+                maxLength: 63
+                minLength: 1
+                type: string
+              test:
+                description: Test holds the configuration for Helm test actions for
+                  this HelmRelease.
+                properties:
+                  enable:
+                    description: |-
+                      Enable enables Helm test actions for this HelmRelease after an Helm install
+                      or upgrade action has been performed.
+                    type: boolean
+                  ignoreFailures:
+                    description: |-
+                      IgnoreFailures tells the controller to skip remediation when the Helm tests
+                      are run but fail. Can be overwritten for tests run after install or upgrade
+                      actions in 'Install.IgnoreTestFailures' and 'Upgrade.IgnoreTestFailures'.
+                    type: boolean
+                  timeout:
+                    description: |-
+                      Timeout is the time to wait for any individual Kubernetes operation during
+                      the performance of a Helm test action. Defaults to 'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              timeout:
+                description: |-
+                  Timeout is the time to wait for any individual Kubernetes operation (like Jobs
+                  for hooks) during the performance of a Helm action. Defaults to '5m0s'.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              uninstall:
+                description: Uninstall holds the configuration for Helm uninstall
+                  actions for this HelmRelease.
+                properties:
+                  deletionPropagation:
+                    default: background
+                    description: |-
+                      DeletionPropagation specifies the deletion propagation policy when
+                      a Helm uninstall is performed.
+                    enum:
+                    - background
+                    - foreground
+                    - orphan
+                    type: string
+                  disableHooks:
+                    description: DisableHooks prevents hooks from running during the
+                      Helm rollback action.
+                    type: boolean
+                  disableWait:
+                    description: |-
+                      DisableWait disables waiting for all the resources to be deleted after
+                      a Helm uninstall is performed.
+                    type: boolean
+                  keepHistory:
+                    description: |-
+                      KeepHistory tells Helm to remove all associated resources and mark the
+                      release as deleted, but retain the release history.
+                    type: boolean
+                  timeout:
+                    description: |-
+                      Timeout is the time to wait for any individual Kubernetes operation (like
+                      Jobs for hooks) during the performance of a Helm uninstall action. Defaults
+                      to 'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              upgrade:
+                description: Upgrade holds the configuration for Helm upgrade actions
+                  for this HelmRelease.
+                properties:
+                  cleanupOnFail:
+                    description: |-
+                      CleanupOnFail allows deletion of new resources created during the Helm
+                      upgrade action when it fails.
+                    type: boolean
+                  crds:
+                    description: |-
+                      CRDs upgrade CRDs from the Helm Chart's crds directory according
+                      to the CRD upgrade policy provided here. Valid values are `Skip`,
+                      `Create` or `CreateReplace`. Default is `Skip` and if omitted
+                      CRDs are neither installed nor upgraded.
+
+
+                      Skip: do neither install nor replace (update) any CRDs.
+
+
+                      Create: new CRDs are created, existing CRDs are neither updated nor deleted.
+
+
+                      CreateReplace: new CRDs are created, existing CRDs are updated (replaced)
+                      but not deleted.
+
+
+                      By default, CRDs are not applied during Helm upgrade action. With this
+                      option users can opt-in to CRD upgrade, which is not (yet) natively supported by Helm.
+                      https://helm.sh/docs/chart_best_practices/custom_resource_definitions.
+                    enum:
+                    - Skip
+                    - Create
+                    - CreateReplace
+                    type: string
+                  disableHooks:
+                    description: DisableHooks prevents hooks from running during the
+                      Helm upgrade action.
+                    type: boolean
+                  disableOpenAPIValidation:
+                    description: |-
+                      DisableOpenAPIValidation prevents the Helm upgrade action from validating
+                      rendered templates against the Kubernetes OpenAPI Schema.
+                    type: boolean
+                  disableWait:
+                    description: |-
+                      DisableWait disables the waiting for resources to be ready after a Helm
+                      upgrade has been performed.
+                    type: boolean
+                  disableWaitForJobs:
+                    description: |-
+                      DisableWaitForJobs disables waiting for jobs to complete after a Helm
+                      upgrade has been performed.
+                    type: boolean
+                  force:
+                    description: Force forces resource updates through a replacement
+                      strategy.
+                    type: boolean
+                  preserveValues:
+                    description: |-
+                      PreserveValues will make Helm reuse the last release's values and merge in
+                      overrides from 'Values'. Setting this flag makes the HelmRelease
+                      non-declarative.
+                    type: boolean
+                  remediation:
+                    description: |-
+                      Remediation holds the remediation configuration for when the Helm upgrade
+                      action for the HelmRelease fails. The default is to not perform any action.
+                    properties:
+                      ignoreTestFailures:
+                        description: |-
+                          IgnoreTestFailures tells the controller to skip remediation when the Helm
+                          tests are run after an upgrade action but fail.
+                          Defaults to 'Test.IgnoreFailures'.
+                        type: boolean
+                      remediateLastFailure:
+                        description: |-
+                          RemediateLastFailure tells the controller to remediate the last failure, when
+                          no retries remain. Defaults to 'false' unless 'Retries' is greater than 0.
+                        type: boolean
+                      retries:
+                        description: |-
+                          Retries is the number of retries that should be attempted on failures before
+                          bailing. Remediation, using 'Strategy', is performed between each attempt.
+                          Defaults to '0', a negative integer equals to unlimited retries.
+                        type: integer
+                      strategy:
+                        description: Strategy to use for failure remediation. Defaults
+                          to 'rollback'.
+                        enum:
+                        - rollback
+                        - uninstall
+                        type: string
+                    type: object
+                  timeout:
+                    description: |-
+                      Timeout is the time to wait for any individual Kubernetes operation (like
+                      Jobs for hooks) during the performance of a Helm upgrade action. Defaults to
+                      'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              values:
+                description: Values holds the values for this Helm release.
+                x-kubernetes-preserve-unknown-fields: true
+              valuesFrom:
+                description: |-
+                  ValuesFrom holds references to resources containing Helm values for this HelmRelease,
+                  and information about how they should be merged.
+                items:
+                  description: |-
+                    ValuesReference contains a reference to a resource containing Helm values,
+                    and optionally the key they can be found at.
+                  properties:
+                    kind:
+                      description: Kind of the values referent, valid values are ('Secret',
+                        'ConfigMap').
+                      enum:
+                      - Secret
+                      - ConfigMap
+                      type: string
+                    name:
+                      description: |-
+                        Name of the values referent. Should reside in the same namespace as the
+                        referring resource.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    optional:
+                      description: |-
+                        Optional marks this ValuesReference as optional. When set, a not found error
+                        for the values reference is ignored, but any ValuesKey, TargetPath or
+                        transient error will still result in a reconciliation failure.
+                      type: boolean
+                    targetPath:
+                      description: |-
+                        TargetPath is the YAML dot notation path the value should be merged at. When
+                        set, the ValuesKey is expected to be a single flat value. Defaults to 'None',
+                        which results in the values getting merged at the root.
+                      maxLength: 250
+                      pattern: ^([a-zA-Z0-9_\-.\\\/]|\[[0-9]{1,5}\])+$
+                      type: string
+                    valuesKey:
+                      description: |-
+                        ValuesKey is the data key where the values.yaml or a specific value can be
+                        found at. Defaults to 'values.yaml'.
+                        When set, must be a valid Data Key, consisting of alphanumeric characters,
+                        '-', '_' or '.'.
+                      maxLength: 253
+                      pattern: ^[\-._a-zA-Z0-9]+$
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                type: array
+            required:
+            - interval
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: HelmReleaseStatus defines the observed state of a HelmRelease.
+            properties:
+              conditions:
+                description: Conditions holds the conditions for the HelmRelease.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              failures:
+                description: |-
+                  Failures is the reconciliation failure count against the latest desired
+                  state. It is reset after a successful reconciliation.
+                format: int64
+                type: integer
+              helmChart:
+                description: |-
+                  HelmChart is the namespaced name of the HelmChart resource created by
+                  the controller for the HelmRelease.
+                type: string
+              history:
+                description: |-
+                  History holds the history of Helm releases performed for this HelmRelease
+                  up to the last successfully completed release.
+
+
+                  Note: this field is provisional to the v2beta2 API, and not actively used
+                  by v2beta1 HelmReleases.
+                items:
+                  description: |-
+                    Snapshot captures a point-in-time copy of the status information for a Helm release,
+                    as managed by the controller.
+                  properties:
+                    apiVersion:
+                      description: |-
+                        APIVersion is the API version of the Snapshot.
+                        Provisional: when the calculation method of the Digest field is changed,
+                        this field will be used to distinguish between the old and new methods.
+                      type: string
+                    appVersion:
+                      description: AppVersion is the chart app version of the release
+                        object in storage.
+                      type: string
+                    chartName:
+                      description: ChartName is the chart name of the release object
+                        in storage.
+                      type: string
+                    chartVersion:
+                      description: |-
+                        ChartVersion is the chart version of the release object in
+                        storage.
+                      type: string
+                    configDigest:
+                      description: |-
+                        ConfigDigest is the checksum of the config (better known as
+                        "values") of the release object in storage.
+                        It has the format of `<algo>:<checksum>`.
+                      type: string
+                    deleted:
+                      description: Deleted is when the release was deleted.
+                      format: date-time
+                      type: string
+                    digest:
+                      description: |-
+                        Digest is the checksum of the release object in storage.
+                        It has the format of `<algo>:<checksum>`.
+                      type: string
+                    firstDeployed:
+                      description: FirstDeployed is when the release was first deployed.
+                      format: date-time
+                      type: string
+                    lastDeployed:
+                      description: LastDeployed is when the release was last deployed.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the release.
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace the release is deployed
+                        to.
+                      type: string
+                    ociDigest:
+                      description: OCIDigest is the digest of the OCI artifact associated
+                        with the release.
+                      type: string
+                    status:
+                      description: Status is the current state of the release.
+                      type: string
+                    testHooks:
+                      additionalProperties:
+                        description: |-
+                          TestHookStatus holds the status information for a test hook as observed
+                          to be run by the controller.
+                        properties:
+                          lastCompleted:
+                            description: LastCompleted is the time the test hook last
+                              completed.
+                            format: date-time
+                            type: string
+                          lastStarted:
+                            description: LastStarted is the time the test hook was
+                              last started.
+                            format: date-time
+                            type: string
+                          phase:
+                            description: Phase the test hook was observed to be in.
+                            type: string
+                        type: object
+                      description: |-
+                        TestHooks is the list of test hooks for the release as observed to be
+                        run by the controller.
+                      type: object
+                    version:
+                      description: Version is the version of the release object in
+                        storage.
+                      type: integer
+                  required:
+                  - chartName
+                  - chartVersion
+                  - configDigest
+                  - digest
+                  - firstDeployed
+                  - lastDeployed
+                  - name
+                  - namespace
+                  - status
+                  - version
+                  type: object
+                type: array
+              installFailures:
+                description: |-
+                  InstallFailures is the install failure count against the latest desired
+                  state. It is reset after a successful reconciliation.
+                format: int64
+                type: integer
+              lastAppliedRevision:
+                description: LastAppliedRevision is the revision of the last successfully
+                  applied source.
+                type: string
+              lastAttemptedConfigDigest:
+                description: |-
+                  LastAttemptedConfigDigest is the digest for the config (better known as
+                  "values") of the last reconciliation attempt.
+
+
+                  Note: this field is provisional to the v2beta2 API, and not actively used
+                  by v2beta1 HelmReleases.
+                type: string
+              lastAttemptedGeneration:
+                description: |-
+                  LastAttemptedGeneration is the last generation the controller attempted
+                  to reconcile.
+
+
+                  Note: this field is provisional to the v2beta2 API, and not actively used
+                  by v2beta1 HelmReleases.
+                format: int64
+                type: integer
+              lastAttemptedReleaseAction:
+                description: |-
+                  LastAttemptedReleaseAction is the last release action performed for this
+                  HelmRelease. It is used to determine the active remediation strategy.
+
+
+                  Note: this field is provisional to the v2beta2 API, and not actively used
+                  by v2beta1 HelmReleases.
+                type: string
+              lastAttemptedRevision:
+                description: LastAttemptedRevision is the revision of the last reconciliation
+                  attempt.
+                type: string
+              lastAttemptedValuesChecksum:
+                description: |-
+                  LastAttemptedValuesChecksum is the SHA1 checksum of the values of the last
+                  reconciliation attempt.
+                type: string
+              lastHandledForceAt:
+                description: |-
+                  LastHandledForceAt holds the value of the most recent force request
+                  value, so a change of the annotation value can be detected.
+
+
+                  Note: this field is provisional to the v2beta2 API, and not actively used
+                  by v2beta1 HelmReleases.
+                type: string
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              lastHandledResetAt:
+                description: |-
+                  LastHandledResetAt holds the value of the most recent reset request
+                  value, so a change of the annotation value can be detected.
+
+
+                  Note: this field is provisional to the v2beta2 API, and not actively used
+                  by v2beta1 HelmReleases.
+                type: string
+              lastReleaseRevision:
+                description: LastReleaseRevision is the revision of the last successful
+                  Helm release.
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation.
+                format: int64
+                type: integer
+              observedPostRenderersDigest:
+                description: |-
+                  ObservedPostRenderersDigest is the digest for the post-renderers of
+                  the last successful reconciliation attempt.
+                type: string
+              storageNamespace:
+                description: |-
+                  StorageNamespace is the namespace of the Helm release storage for the
+                  current release.
+
+
+                  Note: this field is provisional to the v2beta2 API, and not actively used
+                  by v2beta1 HelmReleases.
+                type: string
+              upgradeFailures:
+                description: |-
+                  UpgradeFailures is the upgrade failure count against the latest desired
+                  state. It is reset after a successful reconciliation.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    deprecated: true
+    deprecationWarning: v2beta2 HelmRelease is deprecated, upgrade to v2
+    name: v2beta2
+    schema:
+      openAPIV3Schema:
+        description: HelmRelease is the Schema for the helmreleases API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HelmReleaseSpec defines the desired state of a Helm release.
+            properties:
+              chart:
+                description: |-
+                  Chart defines the template of the v1beta2.HelmChart that should be created
+                  for this HelmRelease.
+                properties:
+                  metadata:
+                    description: ObjectMeta holds the template for metadata like labels
+                      and annotations.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+                        type: object
+                    type: object
+                  spec:
+                    description: Spec holds the template for the v1beta2.HelmChartSpec
+                      for this HelmRelease.
+                    properties:
+                      chart:
+                        description: The name or path the Helm chart is available
+                          at in the SourceRef.
+                        maxLength: 2048
+                        minLength: 1
+                        type: string
+                      ignoreMissingValuesFiles:
+                        description: IgnoreMissingValuesFiles controls whether to
+                          silently ignore missing values files rather than failing.
+                        type: boolean
+                      interval:
+                        description: |-
+                          Interval at which to check the v1.Source for updates. Defaults to
+                          'HelmReleaseSpec.Interval'.
+                        pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                        type: string
+                      reconcileStrategy:
+                        default: ChartVersion
+                        description: |-
+                          Determines what enables the creation of a new artifact. Valid values are
+                          ('ChartVersion', 'Revision').
+                          See the documentation of the values for an explanation on their behavior.
+                          Defaults to ChartVersion when omitted.
+                        enum:
+                        - ChartVersion
+                        - Revision
+                        type: string
+                      sourceRef:
+                        description: The name and namespace of the v1.Source the chart
+                          is available at.
+                        properties:
+                          apiVersion:
+                            description: APIVersion of the referent.
+                            type: string
+                          kind:
+                            description: Kind of the referent.
+                            enum:
+                            - HelmRepository
+                            - GitRepository
+                            - Bucket
+                            type: string
+                          name:
+                            description: Name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: Namespace of the referent.
+                            maxLength: 63
+                            minLength: 1
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      valuesFile:
+                        description: |-
+                          Alternative values file to use as the default chart values, expected to
+                          be a relative path in the SourceRef. Deprecated in favor of ValuesFiles,
+                          for backwards compatibility the file defined here is merged before the
+                          ValuesFiles items. Ignored when omitted.
+                        type: string
+                      valuesFiles:
+                        description: |-
+                          Alternative list of values files to use as the chart values (values.yaml
+                          is not included by default), expected to be a relative path in the SourceRef.
+                          Values files are merged in the order of this list with the last file overriding
+                          the first. Ignored when omitted.
+                        items:
+                          type: string
+                        type: array
+                      verify:
+                        description: |-
+                          Verify contains the secret name containing the trusted public keys
+                          used to verify the signature and specifies which provider to use to check
+                          whether OCI image is authentic.
+                          This field is only supported for OCI sources.
+                          Chart dependencies, which are not bundled in the umbrella chart artifact,
+                          are not verified.
+                        properties:
+                          provider:
+                            default: cosign
+                            description: Provider specifies the technology used to
+                              sign the OCI Helm chart.
+                            enum:
+                            - cosign
+                            - notation
+                            type: string
+                          secretRef:
+                            description: |-
+                              SecretRef specifies the Kubernetes Secret containing the
+                              trusted public keys.
+                            properties:
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                        required:
+                        - provider
+                        type: object
+                      version:
+                        default: '*'
+                        description: |-
+                          Version semver expression, ignored for charts from v1beta2.GitRepository and
+                          v1beta2.Bucket sources. Defaults to latest when omitted.
+                        type: string
+                    required:
+                    - chart
+                    - sourceRef
+                    type: object
+                required:
+                - spec
+                type: object
+              chartRef:
+                description: |-
+                  ChartRef holds a reference to a source controller resource containing the
+                  Helm chart artifact.
+
+
+                  Note: this field is provisional to the v2 API, and not actively used
+                  by v2beta2 HelmReleases.
+                properties:
+                  apiVersion:
+                    description: APIVersion of the referent.
+                    type: string
+                  kind:
+                    description: Kind of the referent.
+                    enum:
+                    - OCIRepository
+                    - HelmChart
+                    type: string
+                  name:
+                    description: Name of the referent.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent, defaults to the namespace of the Kubernetes
+                      resource object that contains the reference.
+                    maxLength: 63
+                    minLength: 1
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              dependsOn:
+                description: |-
+                  DependsOn may contain a meta.NamespacedObjectReference slice with
+                  references to HelmRelease resources that must be ready before this HelmRelease
+                  can be reconciled.
+                items:
+                  description: |-
+                    NamespacedObjectReference contains enough information to locate the referenced Kubernetes resource object in any
+                    namespace.
+                  properties:
+                    name:
+                      description: Name of the referent.
+                      type: string
+                    namespace:
+                      description: Namespace of the referent, when not specified it
+                        acts as LocalObjectReference.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              driftDetection:
+                description: |-
+                  DriftDetection holds the configuration for detecting and handling
+                  differences between the manifest in the Helm storage and the resources
+                  currently existing in the cluster.
+                properties:
+                  ignore:
+                    description: |-
+                      Ignore contains a list of rules for specifying which changes to ignore
+                      during diffing.
+                    items:
+                      description: |-
+                        IgnoreRule defines a rule to selectively disregard specific changes during
+                        the drift detection process.
+                      properties:
+                        paths:
+                          description: |-
+                            Paths is a list of JSON Pointer (RFC 6901) paths to be excluded from
+                            consideration in a Kubernetes object.
+                          items:
+                            type: string
+                          type: array
+                        target:
+                          description: |-
+                            Target is a selector for specifying Kubernetes objects to which this
+                            rule applies.
+                            If Target is not set, the Paths will be ignored for all Kubernetes
+                            objects within the manifest of the Helm release.
+                          properties:
+                            annotationSelector:
+                              description: |-
+                                AnnotationSelector is a string that follows the label selection expression
+                                https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                It matches with the resource annotations.
+                              type: string
+                            group:
+                              description: |-
+                                Group is the API group to select resources from.
+                                Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                              type: string
+                            kind:
+                              description: |-
+                                Kind of the API Group to select resources from.
+                                Together with Group and Version it is capable of unambiguously
+                                identifying and/or selecting resources.
+                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                              type: string
+                            labelSelector:
+                              description: |-
+                                LabelSelector is a string that follows the label selection expression
+                                https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                It matches with the resource labels.
+                              type: string
+                            name:
+                              description: Name to match resources with.
+                              type: string
+                            namespace:
+                              description: Namespace to select resources from.
+                              type: string
+                            version:
+                              description: |-
+                                Version of the API Group to select resources from.
+                                Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                              type: string
+                          type: object
+                      required:
+                      - paths
+                      type: object
+                    type: array
+                  mode:
+                    description: |-
+                      Mode defines how differences should be handled between the Helm manifest
+                      and the manifest currently applied to the cluster.
+                      If not explicitly set, it defaults to DiffModeDisabled.
+                    enum:
+                    - enabled
+                    - warn
+                    - disabled
+                    type: string
+                type: object
+              install:
+                description: Install holds the configuration for Helm install actions
+                  for this HelmRelease.
+                properties:
+                  crds:
+                    description: |-
+                      CRDs upgrade CRDs from the Helm Chart's crds directory according
+                      to the CRD upgrade policy provided here. Valid values are `Skip`,
+                      `Create` or `CreateReplace`. Default is `Create` and if omitted
+                      CRDs are installed but not updated.
+
+
+                      Skip: do neither install nor replace (update) any CRDs.
+
+
+                      Create: new CRDs are created, existing CRDs are neither updated nor deleted.
+
+
+                      CreateReplace: new CRDs are created, existing CRDs are updated (replaced)
+                      but not deleted.
+
+
+                      By default, CRDs are applied (installed) during Helm install action.
+                      With this option users can opt in to CRD replace existing CRDs on Helm
+                      install actions, which is not (yet) natively supported by Helm.
+                      https://helm.sh/docs/chart_best_practices/custom_resource_definitions.
+                    enum:
+                    - Skip
+                    - Create
+                    - CreateReplace
+                    type: string
+                  createNamespace:
+                    description: |-
+                      CreateNamespace tells the Helm install action to create the
+                      HelmReleaseSpec.TargetNamespace if it does not exist yet.
+                      On uninstall, the namespace will not be garbage collected.
+                    type: boolean
+                  disableHooks:
+                    description: DisableHooks prevents hooks from running during the
+                      Helm install action.
+                    type: boolean
+                  disableOpenAPIValidation:
+                    description: |-
+                      DisableOpenAPIValidation prevents the Helm install action from validating
+                      rendered templates against the Kubernetes OpenAPI Schema.
+                    type: boolean
+                  disableWait:
+                    description: |-
+                      DisableWait disables the waiting for resources to be ready after a Helm
+                      install has been performed.
+                    type: boolean
+                  disableWaitForJobs:
+                    description: |-
+                      DisableWaitForJobs disables waiting for jobs to complete after a Helm
+                      install has been performed.
+                    type: boolean
+                  remediation:
+                    description: |-
+                      Remediation holds the remediation configuration for when the Helm install
+                      action for the HelmRelease fails. The default is to not perform any action.
+                    properties:
+                      ignoreTestFailures:
+                        description: |-
+                          IgnoreTestFailures tells the controller to skip remediation when the Helm
+                          tests are run after an install action but fail. Defaults to
+                          'Test.IgnoreFailures'.
+                        type: boolean
+                      remediateLastFailure:
+                        description: |-
+                          RemediateLastFailure tells the controller to remediate the last failure, when
+                          no retries remain. Defaults to 'false'.
+                        type: boolean
+                      retries:
+                        description: |-
+                          Retries is the number of retries that should be attempted on failures before
+                          bailing. Remediation, using an uninstall, is performed between each attempt.
+                          Defaults to '0', a negative integer equals to unlimited retries.
+                        type: integer
+                    type: object
+                  replace:
+                    description: |-
+                      Replace tells the Helm install action to re-use the 'ReleaseName', but only
+                      if that name is a deleted release which remains in the history.
+                    type: boolean
+                  skipCRDs:
+                    description: |-
+                      SkipCRDs tells the Helm install action to not install any CRDs. By default,
+                      CRDs are installed if not already present.
+
+
+                      Deprecated use CRD policy (`crds`) attribute with value `Skip` instead.
+                    type: boolean
+                  timeout:
+                    description: |-
+                      Timeout is the time to wait for any individual Kubernetes operation (like
+                      Jobs for hooks) during the performance of a Helm install action. Defaults to
+                      'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              interval:
+                description: Interval at which to reconcile the Helm release.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              kubeConfig:
+                description: |-
+                  KubeConfig for reconciling the HelmRelease on a remote cluster.
+                  When used in combination with HelmReleaseSpec.ServiceAccountName,
+                  forces the controller to act on behalf of that Service Account at the
+                  target cluster.
+                  If the --default-service-account flag is set, its value will be used as
+                  a controller level fallback for when HelmReleaseSpec.ServiceAccountName
+                  is empty.
+                properties:
+                  secretRef:
+                    description: |-
+                      SecretRef holds the name of a secret that contains a key with
+                      the kubeconfig file as the value. If no key is set, the key will default
+                      to 'value'.
+                      It is recommended that the kubeconfig is self-contained, and the secret
+                      is regularly updated if credentials such as a cloud-access-token expire.
+                      Cloud specific `cmd-path` auth helpers will not function without adding
+                      binaries and credentials to the Pod that is responsible for reconciling
+                      Kubernetes resources.
+                    properties:
+                      key:
+                        description: Key in the Secret, when not specified an implementation-specific
+                          default key is used.
+                        type: string
+                      name:
+                        description: Name of the Secret.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - secretRef
+                type: object
+              maxHistory:
+                description: |-
+                  MaxHistory is the number of revisions saved by Helm for this HelmRelease.
+                  Use '0' for an unlimited number of revisions; defaults to '5'.
+                type: integer
+              persistentClient:
+                description: |-
+                  PersistentClient tells the controller to use a persistent Kubernetes
+                  client for this release. When enabled, the client will be reused for the
+                  duration of the reconciliation, instead of being created and destroyed
+                  for each (step of a) Helm action.
+
+
+                  This can improve performance, but may cause issues with some Helm charts
+                  that for example do create Custom Resource Definitions during installation
+                  outside Helm's CRD lifecycle hooks, which are then not observed to be
+                  available by e.g. post-install hooks.
+
+
+                  If not set, it defaults to true.
+                type: boolean
+              postRenderers:
+                description: |-
+                  PostRenderers holds an array of Helm PostRenderers, which will be applied in order
+                  of their definition.
+                items:
+                  description: PostRenderer contains a Helm PostRenderer specification.
+                  properties:
+                    kustomize:
+                      description: Kustomization to apply as PostRenderer.
+                      properties:
+                        images:
+                          description: |-
+                            Images is a list of (image name, new name, new tag or digest)
+                            for changing image names, tags or digests. This can also be achieved with a
+                            patch, but this operator is simpler to specify.
+                          items:
+                            description: Image contains an image name, a new name,
+                              a new tag or digest, which will replace the original
+                              name and tag.
+                            properties:
+                              digest:
+                                description: |-
+                                  Digest is the value used to replace the original image tag.
+                                  If digest is present NewTag value is ignored.
+                                type: string
+                              name:
+                                description: Name is a tag-less image name.
+                                type: string
+                              newName:
+                                description: NewName is the value used to replace
+                                  the original name.
+                                type: string
+                              newTag:
+                                description: NewTag is the value used to replace the
+                                  original tag.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        patches:
+                          description: |-
+                            Strategic merge and JSON patches, defined as inline YAML objects,
+                            capable of targeting objects based on kind, label and annotation selectors.
+                          items:
+                            description: |-
+                              Patch contains an inline StrategicMerge or JSON6902 patch, and the target the patch should
+                              be applied to.
+                            properties:
+                              patch:
+                                description: |-
+                                  Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with
+                                  an array of operation objects.
+                                type: string
+                              target:
+                                description: Target points to the resources that the
+                                  patch document should be applied to.
+                                properties:
+                                  annotationSelector:
+                                    description: |-
+                                      AnnotationSelector is a string that follows the label selection expression
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                      It matches with the resource annotations.
+                                    type: string
+                                  group:
+                                    description: |-
+                                      Group is the API group to select resources from.
+                                      Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                    type: string
+                                  kind:
+                                    description: |-
+                                      Kind of the API Group to select resources from.
+                                      Together with Group and Version it is capable of unambiguously
+                                      identifying and/or selecting resources.
+                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                    type: string
+                                  labelSelector:
+                                    description: |-
+                                      LabelSelector is a string that follows the label selection expression
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                      It matches with the resource labels.
+                                    type: string
+                                  name:
+                                    description: Name to match resources with.
+                                    type: string
+                                  namespace:
+                                    description: Namespace to select resources from.
+                                    type: string
+                                  version:
+                                    description: |-
+                                      Version of the API Group to select resources from.
+                                      Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                    type: string
+                                type: object
+                            required:
+                            - patch
+                            type: object
+                          type: array
+                        patchesJson6902:
+                          description: |-
+                            JSON 6902 patches, defined as inline YAML objects.
+                            Deprecated: use Patches instead.
+                          items:
+                            description: JSON6902Patch contains a JSON6902 patch and
+                              the target the patch should be applied to.
+                            properties:
+                              patch:
+                                description: Patch contains the JSON6902 patch document
+                                  with an array of operation objects.
+                                items:
+                                  description: |-
+                                    JSON6902 is a JSON6902 operation object.
+                                    https://datatracker.ietf.org/doc/html/rfc6902#section-4
+                                  properties:
+                                    from:
+                                      description: |-
+                                        From contains a JSON-pointer value that references a location within the target document where the operation is
+                                        performed. The meaning of the value depends on the value of Op, and is NOT taken into account by all operations.
+                                      type: string
+                                    op:
+                                      description: |-
+                                        Op indicates the operation to perform. Its value MUST be one of "add", "remove", "replace", "move", "copy", or
+                                        "test".
+                                        https://datatracker.ietf.org/doc/html/rfc6902#section-4
+                                      enum:
+                                      - test
+                                      - remove
+                                      - add
+                                      - replace
+                                      - move
+                                      - copy
+                                      type: string
+                                    path:
+                                      description: |-
+                                        Path contains the JSON-pointer value that references a location within the target document where the operation
+                                        is performed. The meaning of the value depends on the value of Op.
+                                      type: string
+                                    value:
+                                      description: |-
+                                        Value contains a valid JSON structure. The meaning of the value depends on the value of Op, and is NOT taken into
+                                        account by all operations.
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  required:
+                                  - op
+                                  - path
+                                  type: object
+                                type: array
+                              target:
+                                description: Target points to the resources that the
+                                  patch document should be applied to.
+                                properties:
+                                  annotationSelector:
+                                    description: |-
+                                      AnnotationSelector is a string that follows the label selection expression
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                      It matches with the resource annotations.
+                                    type: string
+                                  group:
+                                    description: |-
+                                      Group is the API group to select resources from.
+                                      Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                    type: string
+                                  kind:
+                                    description: |-
+                                      Kind of the API Group to select resources from.
+                                      Together with Group and Version it is capable of unambiguously
+                                      identifying and/or selecting resources.
+                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                    type: string
+                                  labelSelector:
+                                    description: |-
+                                      LabelSelector is a string that follows the label selection expression
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                      It matches with the resource labels.
+                                    type: string
+                                  name:
+                                    description: Name to match resources with.
+                                    type: string
+                                  namespace:
+                                    description: Namespace to select resources from.
+                                    type: string
+                                  version:
+                                    description: |-
+                                      Version of the API Group to select resources from.
+                                      Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                    type: string
+                                type: object
+                            required:
+                            - patch
+                            - target
+                            type: object
+                          type: array
+                        patchesStrategicMerge:
+                          description: |-
+                            Strategic merge patches, defined as inline YAML objects.
+                            Deprecated: use Patches instead.
+                          items:
+                            x-kubernetes-preserve-unknown-fields: true
+                          type: array
+                      type: object
+                  type: object
+                type: array
+              releaseName:
+                description: |-
+                  ReleaseName used for the Helm release. Defaults to a composition of
+                  '[TargetNamespace-]Name'.
+                maxLength: 53
+                minLength: 1
+                type: string
+              rollback:
+                description: Rollback holds the configuration for Helm rollback actions
+                  for this HelmRelease.
+                properties:
+                  cleanupOnFail:
+                    description: |-
+                      CleanupOnFail allows deletion of new resources created during the Helm
+                      rollback action when it fails.
+                    type: boolean
+                  disableHooks:
+                    description: DisableHooks prevents hooks from running during the
+                      Helm rollback action.
+                    type: boolean
+                  disableWait:
+                    description: |-
+                      DisableWait disables the waiting for resources to be ready after a Helm
+                      rollback has been performed.
+                    type: boolean
+                  disableWaitForJobs:
+                    description: |-
+                      DisableWaitForJobs disables waiting for jobs to complete after a Helm
+                      rollback has been performed.
+                    type: boolean
+                  force:
+                    description: Force forces resource updates through a replacement
+                      strategy.
+                    type: boolean
+                  recreate:
+                    description: Recreate performs pod restarts for the resource if
+                      applicable.
+                    type: boolean
+                  timeout:
+                    description: |-
+                      Timeout is the time to wait for any individual Kubernetes operation (like
+                      Jobs for hooks) during the performance of a Helm rollback action. Defaults to
+                      'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              serviceAccountName:
+                description: |-
+                  The name of the Kubernetes service account to impersonate
+                  when reconciling this HelmRelease.
+                maxLength: 253
+                minLength: 1
+                type: string
+              storageNamespace:
+                description: |-
+                  StorageNamespace used for the Helm storage.
+                  Defaults to the namespace of the HelmRelease.
+                maxLength: 63
+                minLength: 1
+                type: string
+              suspend:
+                description: |-
+                  Suspend tells the controller to suspend reconciliation for this HelmRelease,
+                  it does not apply to already started reconciliations. Defaults to false.
+                type: boolean
+              targetNamespace:
+                description: |-
+                  TargetNamespace to target when performing operations for the HelmRelease.
+                  Defaults to the namespace of the HelmRelease.
+                maxLength: 63
+                minLength: 1
+                type: string
+              test:
+                description: Test holds the configuration for Helm test actions for
+                  this HelmRelease.
+                properties:
+                  enable:
+                    description: |-
+                      Enable enables Helm test actions for this HelmRelease after an Helm install
+                      or upgrade action has been performed.
+                    type: boolean
+                  filters:
+                    description: Filters is a list of tests to run or exclude from
+                      running.
+                    items:
+                      description: Filter holds the configuration for individual Helm
+                        test filters.
+                      properties:
+                        exclude:
+                          description: Exclude specifies whether the named test should
+                            be excluded.
+                          type: boolean
+                        name:
+                          description: Name is the name of the test.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  ignoreFailures:
+                    description: |-
+                      IgnoreFailures tells the controller to skip remediation when the Helm tests
+                      are run but fail. Can be overwritten for tests run after install or upgrade
+                      actions in 'Install.IgnoreTestFailures' and 'Upgrade.IgnoreTestFailures'.
+                    type: boolean
+                  timeout:
+                    description: |-
+                      Timeout is the time to wait for any individual Kubernetes operation during
+                      the performance of a Helm test action. Defaults to 'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              timeout:
+                description: |-
+                  Timeout is the time to wait for any individual Kubernetes operation (like Jobs
+                  for hooks) during the performance of a Helm action. Defaults to '5m0s'.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              uninstall:
+                description: Uninstall holds the configuration for Helm uninstall
+                  actions for this HelmRelease.
+                properties:
+                  deletionPropagation:
+                    default: background
+                    description: |-
+                      DeletionPropagation specifies the deletion propagation policy when
+                      a Helm uninstall is performed.
+                    enum:
+                    - background
+                    - foreground
+                    - orphan
+                    type: string
+                  disableHooks:
+                    description: DisableHooks prevents hooks from running during the
+                      Helm rollback action.
+                    type: boolean
+                  disableWait:
+                    description: |-
+                      DisableWait disables waiting for all the resources to be deleted after
+                      a Helm uninstall is performed.
+                    type: boolean
+                  keepHistory:
+                    description: |-
+                      KeepHistory tells Helm to remove all associated resources and mark the
+                      release as deleted, but retain the release history.
+                    type: boolean
+                  timeout:
+                    description: |-
+                      Timeout is the time to wait for any individual Kubernetes operation (like
+                      Jobs for hooks) during the performance of a Helm uninstall action. Defaults
+                      to 'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              upgrade:
+                description: Upgrade holds the configuration for Helm upgrade actions
+                  for this HelmRelease.
+                properties:
+                  cleanupOnFail:
+                    description: |-
+                      CleanupOnFail allows deletion of new resources created during the Helm
+                      upgrade action when it fails.
+                    type: boolean
+                  crds:
+                    description: |-
+                      CRDs upgrade CRDs from the Helm Chart's crds directory according
+                      to the CRD upgrade policy provided here. Valid values are `Skip`,
+                      `Create` or `CreateReplace`. Default is `Skip` and if omitted
+                      CRDs are neither installed nor upgraded.
+
+
+                      Skip: do neither install nor replace (update) any CRDs.
+
+
+                      Create: new CRDs are created, existing CRDs are neither updated nor deleted.
+
+
+                      CreateReplace: new CRDs are created, existing CRDs are updated (replaced)
+                      but not deleted.
+
+
+                      By default, CRDs are not applied during Helm upgrade action. With this
+                      option users can opt-in to CRD upgrade, which is not (yet) natively supported by Helm.
+                      https://helm.sh/docs/chart_best_practices/custom_resource_definitions.
+                    enum:
+                    - Skip
+                    - Create
+                    - CreateReplace
+                    type: string
+                  disableHooks:
+                    description: DisableHooks prevents hooks from running during the
+                      Helm upgrade action.
+                    type: boolean
+                  disableOpenAPIValidation:
+                    description: |-
+                      DisableOpenAPIValidation prevents the Helm upgrade action from validating
+                      rendered templates against the Kubernetes OpenAPI Schema.
+                    type: boolean
+                  disableWait:
+                    description: |-
+                      DisableWait disables the waiting for resources to be ready after a Helm
+                      upgrade has been performed.
+                    type: boolean
+                  disableWaitForJobs:
+                    description: |-
+                      DisableWaitForJobs disables waiting for jobs to complete after a Helm
+                      upgrade has been performed.
+                    type: boolean
+                  force:
+                    description: Force forces resource updates through a replacement
+                      strategy.
+                    type: boolean
+                  preserveValues:
+                    description: |-
+                      PreserveValues will make Helm reuse the last release's values and merge in
+                      overrides from 'Values'. Setting this flag makes the HelmRelease
+                      non-declarative.
+                    type: boolean
+                  remediation:
+                    description: |-
+                      Remediation holds the remediation configuration for when the Helm upgrade
+                      action for the HelmRelease fails. The default is to not perform any action.
+                    properties:
+                      ignoreTestFailures:
+                        description: |-
+                          IgnoreTestFailures tells the controller to skip remediation when the Helm
+                          tests are run after an upgrade action but fail.
+                          Defaults to 'Test.IgnoreFailures'.
+                        type: boolean
+                      remediateLastFailure:
+                        description: |-
+                          RemediateLastFailure tells the controller to remediate the last failure, when
+                          no retries remain. Defaults to 'false' unless 'Retries' is greater than 0.
+                        type: boolean
+                      retries:
+                        description: |-
+                          Retries is the number of retries that should be attempted on failures before
+                          bailing. Remediation, using 'Strategy', is performed between each attempt.
+                          Defaults to '0', a negative integer equals to unlimited retries.
+                        type: integer
+                      strategy:
+                        description: Strategy to use for failure remediation. Defaults
+                          to 'rollback'.
+                        enum:
+                        - rollback
+                        - uninstall
+                        type: string
+                    type: object
+                  timeout:
+                    description: |-
+                      Timeout is the time to wait for any individual Kubernetes operation (like
+                      Jobs for hooks) during the performance of a Helm upgrade action. Defaults to
+                      'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              values:
+                description: Values holds the values for this Helm release.
+                x-kubernetes-preserve-unknown-fields: true
+              valuesFrom:
+                description: |-
+                  ValuesFrom holds references to resources containing Helm values for this HelmRelease,
+                  and information about how they should be merged.
+                items:
+                  description: |-
+                    ValuesReference contains a reference to a resource containing Helm values,
+                    and optionally the key they can be found at.
+                  properties:
+                    kind:
+                      description: Kind of the values referent, valid values are ('Secret',
+                        'ConfigMap').
+                      enum:
+                      - Secret
+                      - ConfigMap
+                      type: string
+                    name:
+                      description: |-
+                        Name of the values referent. Should reside in the same namespace as the
+                        referring resource.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    optional:
+                      description: |-
+                        Optional marks this ValuesReference as optional. When set, a not found error
+                        for the values reference is ignored, but any ValuesKey, TargetPath or
+                        transient error will still result in a reconciliation failure.
+                      type: boolean
+                    targetPath:
+                      description: |-
+                        TargetPath is the YAML dot notation path the value should be merged at. When
+                        set, the ValuesKey is expected to be a single flat value. Defaults to 'None',
+                        which results in the values getting merged at the root.
+                      maxLength: 250
+                      pattern: ^([a-zA-Z0-9_\-.\\\/]|\[[0-9]{1,5}\])+$
+                      type: string
+                    valuesKey:
+                      description: |-
+                        ValuesKey is the data key where the values.yaml or a specific value can be
+                        found at. Defaults to 'values.yaml'.
+                      maxLength: 253
+                      pattern: ^[\-._a-zA-Z0-9]+$
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                type: array
+            required:
+            - interval
+            type: object
+            x-kubernetes-validations:
+            - message: either chart or chartRef must be set
+              rule: (has(self.chart) && !has(self.chartRef)) || (!has(self.chart)
+                && has(self.chartRef))
+          status:
+            default:
+              observedGeneration: -1
+            description: HelmReleaseStatus defines the observed state of a HelmRelease.
+            properties:
+              conditions:
+                description: Conditions holds the conditions for the HelmRelease.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              failures:
+                description: |-
+                  Failures is the reconciliation failure count against the latest desired
+                  state. It is reset after a successful reconciliation.
+                format: int64
+                type: integer
+              helmChart:
+                description: |-
+                  HelmChart is the namespaced name of the HelmChart resource created by
+                  the controller for the HelmRelease.
+                type: string
+              history:
+                description: |-
+                  History holds the history of Helm releases performed for this HelmRelease
+                  up to the last successfully completed release.
+                items:
+                  description: |-
+                    Snapshot captures a point-in-time copy of the status information for a Helm release,
+                    as managed by the controller.
+                  properties:
+                    apiVersion:
+                      description: |-
+                        APIVersion is the API version of the Snapshot.
+                        Provisional: when the calculation method of the Digest field is changed,
+                        this field will be used to distinguish between the old and new methods.
+                      type: string
+                    appVersion:
+                      description: AppVersion is the chart app version of the release
+                        object in storage.
+                      type: string
+                    chartName:
+                      description: ChartName is the chart name of the release object
+                        in storage.
+                      type: string
+                    chartVersion:
+                      description: |-
+                        ChartVersion is the chart version of the release object in
+                        storage.
+                      type: string
+                    configDigest:
+                      description: |-
+                        ConfigDigest is the checksum of the config (better known as
+                        "values") of the release object in storage.
+                        It has the format of `<algo>:<checksum>`.
+                      type: string
+                    deleted:
+                      description: Deleted is when the release was deleted.
+                      format: date-time
+                      type: string
+                    digest:
+                      description: |-
+                        Digest is the checksum of the release object in storage.
+                        It has the format of `<algo>:<checksum>`.
+                      type: string
+                    firstDeployed:
+                      description: FirstDeployed is when the release was first deployed.
+                      format: date-time
+                      type: string
+                    lastDeployed:
+                      description: LastDeployed is when the release was last deployed.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the release.
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace the release is deployed
+                        to.
+                      type: string
+                    ociDigest:
+                      description: OCIDigest is the digest of the OCI artifact associated
+                        with the release.
+                      type: string
+                    status:
+                      description: Status is the current state of the release.
+                      type: string
+                    testHooks:
+                      additionalProperties:
+                        description: |-
+                          TestHookStatus holds the status information for a test hook as observed
+                          to be run by the controller.
+                        properties:
+                          lastCompleted:
+                            description: LastCompleted is the time the test hook last
+                              completed.
+                            format: date-time
+                            type: string
+                          lastStarted:
+                            description: LastStarted is the time the test hook was
+                              last started.
+                            format: date-time
+                            type: string
+                          phase:
+                            description: Phase the test hook was observed to be in.
+                            type: string
+                        type: object
+                      description: |-
+                        TestHooks is the list of test hooks for the release as observed to be
+                        run by the controller.
+                      type: object
+                    version:
+                      description: Version is the version of the release object in
+                        storage.
+                      type: integer
+                  required:
+                  - chartName
+                  - chartVersion
+                  - configDigest
+                  - digest
+                  - firstDeployed
+                  - lastDeployed
+                  - name
+                  - namespace
+                  - status
+                  - version
+                  type: object
+                type: array
+              installFailures:
+                description: |-
+                  InstallFailures is the install failure count against the latest desired
+                  state. It is reset after a successful reconciliation.
+                format: int64
+                type: integer
+              lastAppliedRevision:
+                description: |-
+                  LastAppliedRevision is the revision of the last successfully applied
+                  source.
+                  Deprecated: the revision can now be found in the History.
+                type: string
+              lastAttemptedConfigDigest:
+                description: |-
+                  LastAttemptedConfigDigest is the digest for the config (better known as
+                  "values") of the last reconciliation attempt.
+                type: string
+              lastAttemptedGeneration:
+                description: |-
+                  LastAttemptedGeneration is the last generation the controller attempted
+                  to reconcile.
+                format: int64
+                type: integer
+              lastAttemptedReleaseAction:
+                description: |-
+                  LastAttemptedReleaseAction is the last release action performed for this
+                  HelmRelease. It is used to determine the active remediation strategy.
+                enum:
+                - install
+                - upgrade
+                type: string
+              lastAttemptedRevision:
+                description: |-
+                  LastAttemptedRevision is the Source revision of the last reconciliation
+                  attempt. For OCIRepository  sources, the 12 first characters of the digest are
+                  appended to the chart version e.g. "1.2.3+1234567890ab".
+                type: string
+              lastAttemptedRevisionDigest:
+                description: |-
+                  LastAttemptedRevisionDigest is the digest of the last reconciliation attempt.
+                  This is only set for OCIRepository sources.
+                type: string
+              lastAttemptedValuesChecksum:
+                description: |-
+                  LastAttemptedValuesChecksum is the SHA1 checksum for the values of the last
+                  reconciliation attempt.
+                  Deprecated: Use LastAttemptedConfigDigest instead.
+                type: string
+              lastHandledForceAt:
+                description: |-
+                  LastHandledForceAt holds the value of the most recent force request
+                  value, so a change of the annotation value can be detected.
+                type: string
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              lastHandledResetAt:
+                description: |-
+                  LastHandledResetAt holds the value of the most recent reset request
+                  value, so a change of the annotation value can be detected.
+                type: string
+              lastReleaseRevision:
+                description: |-
+                  LastReleaseRevision is the revision of the last successful Helm release.
+                  Deprecated: Use History instead.
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation.
+                format: int64
+                type: integer
+              observedPostRenderersDigest:
+                description: |-
+                  ObservedPostRenderersDigest is the digest for the post-renderers of
+                  the last successful reconciliation attempt.
+                type: string
+              storageNamespace:
+                description: |-
+                  StorageNamespace is the namespace of the Helm release storage for the
+                  current release.
+                maxLength: 63
+                minLength: 1
+                type: string
+              upgradeFailures:
+                description: |-
+                  UpgradeFailures is the upgrade failure count against the latest desired
+                  state. It is reset after a successful reconciliation.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - bases/helm.toolkit.fluxcd.io_helmreleases.yaml
+  - bases/cd.qdrant.io_helmreleases.yaml
 # +kubebuilder:scaffold:crdkustomizeresource

--- a/config/rbac/helmrelease_editor_role.yaml
+++ b/config/rbac/helmrelease_editor_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: helmrelease-editor-role
 rules:
 - apiGroups:
-  - helm.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - helmreleases
   verbs:
@@ -17,7 +17,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - helm.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - helmreleases/status
   verbs:

--- a/config/rbac/helmrelease_viewer_role.yaml
+++ b/config/rbac/helmrelease_viewer_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: helmrelease-viewer-role
 rules:
 - apiGroups:
-  - helm.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - helmreleases
   verbs:
@@ -13,7 +13,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - helm.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - helmreleases/status
   verbs:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -12,7 +12,21 @@ rules:
   - create
   - patch
 - apiGroups:
-  - helm.toolkit.fluxcd.io
+  - cd.qdrant.io
+  resources:
+  - helmcharts
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cd.qdrant.io
+  resources:
+  - helmcharts/status
+  verbs:
+  - get
+- apiGroups:
+  - cd.qdrant.io
   resources:
   - helmreleases
   verbs:
@@ -24,7 +38,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - helm.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - helmreleases/finalizers
   verbs:
@@ -34,7 +48,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - helm.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - helmreleases/status
   verbs:
@@ -42,21 +56,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - source.toolkit.fluxcd.io
-  resources:
-  - helmcharts
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - source.toolkit.fluxcd.io
-  resources:
-  - helmcharts/status
-  verbs:
-  - get
-- apiGroups:
-  - source.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - ocirepositories
   verbs:
@@ -64,7 +64,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - source.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - ocirepositories/status
   verbs:

--- a/config/samples/helm_v2_helmrelease_gitrepository.yaml
+++ b/config/samples/helm_v2_helmrelease_gitrepository.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2
+apiVersion: cd.qdrant.io/v2
 kind: HelmRelease
 metadata:
   name: podinfo-gitrepository

--- a/config/samples/helm_v2_helmrelease_helmrepository.yaml
+++ b/config/samples/helm_v2_helmrelease_helmrepository.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2
+apiVersion: cd.qdrant.io/v2
 kind: HelmRelease
 metadata:
   name: podinfo-helmrepository

--- a/config/samples/helm_v2_helmrelease_ocirepository.yaml
+++ b/config/samples/helm_v2_helmrelease_ocirepository.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2
+apiVersion: cd.qdrant.io/v2
 kind: HelmRelease
 metadata:
   name: podinfo-ocirepository

--- a/config/samples/source_v1_gitrepository.yaml
+++ b/config/samples/source_v1_gitrepository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: GitRepository
 metadata:
   name: podinfo

--- a/config/samples/source_v1_helmrepository.yaml
+++ b/config/samples/source_v1_helmrepository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: HelmRepository
 metadata:
   name: podinfo

--- a/config/samples/source_v1beta2_ocirepository.yaml
+++ b/config/samples/source_v1beta2_ocirepository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: OCIRepository
 metadata:
   name: podinfo

--- a/config/testdata/charts/crds/bootstrap/templates/git-repository.yaml
+++ b/config/testdata/charts/crds/bootstrap/templates/git-repository.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: GitRepository
 metadata:
   name: this

--- a/config/testdata/charts/crds/v1/crds/a.yaml
+++ b/config/testdata/charts/crds/v1/crds/a.yaml
@@ -3,9 +3,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: crdupgradetestas.crd-upgrades.helmreleases.helm.toolkit.fluxcd.io
+  name: crdupgradetestas.crd-upgrades.helmreleases.cd.qdrant.io
 spec:
-  group: crd-upgrades.helmreleases.helm.toolkit.fluxcd.io
+  group: crd-upgrades.helmreleases.cd.qdrant.io
   names:
     kind: CrdUpgradeTesta
     listKind: CrdUpgradeTestaList

--- a/config/testdata/charts/crds/v1/crds/b.yaml
+++ b/config/testdata/charts/crds/v1/crds/b.yaml
@@ -3,9 +3,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: crdupgradetestbs.crd-upgrades.helmreleases.helm.toolkit.fluxcd.io
+  name: crdupgradetestbs.crd-upgrades.helmreleases.cd.qdrant.io
 spec:
-  group: crd-upgrades.helmreleases.helm.toolkit.fluxcd.io
+  group: crd-upgrades.helmreleases.cd.qdrant.io
   names:
     kind: CrdUpgradeTestb
     listKind: CrdUpgradeTestbList

--- a/config/testdata/charts/crds/v1/crds/d.yaml
+++ b/config/testdata/charts/crds/v1/crds/d.yaml
@@ -3,9 +3,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: crdupgradetestds.crd-upgrades.helmreleases.helm.toolkit.fluxcd.io
+  name: crdupgradetestds.crd-upgrades.helmreleases.cd.qdrant.io
 spec:
-  group: crd-upgrades.helmreleases.helm.toolkit.fluxcd.io
+  group: crd-upgrades.helmreleases.cd.qdrant.io
   names:
     kind: CrdUpgradeTestd
     listKind: CrdUpgradeTestdList

--- a/config/testdata/charts/crds/v1/templates/dummy.yaml
+++ b/config/testdata/charts/crds/v1/templates/dummy.yaml
@@ -1,6 +1,6 @@
 ---
 kind: CrdUpgradeTesta
-apiVersion: crd-upgrades.helmreleases.helm.toolkit.fluxcd.io/v2beta1
+apiVersion: crd-upgrades.helmreleases.cd.qdrant.io/v2beta1
 metadata:
   name: a
 spec: {}

--- a/config/testdata/charts/crds/v2/crds/a.yaml
+++ b/config/testdata/charts/crds/v2/crds/a.yaml
@@ -3,9 +3,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: crdupgradetestas.crd-upgrades.helmreleases.helm.toolkit.fluxcd.io
+  name: crdupgradetestas.crd-upgrades.helmreleases.cd.qdrant.io
 spec:
-  group: crd-upgrades.helmreleases.helm.toolkit.fluxcd.io
+  group: crd-upgrades.helmreleases.cd.qdrant.io
   names:
     kind: CrdUpgradeTesta
     listKind: CrdUpgradeTestaList

--- a/config/testdata/charts/crds/v2/crds/b.yaml
+++ b/config/testdata/charts/crds/v2/crds/b.yaml
@@ -3,9 +3,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: crdupgradetestbs.crd-upgrades.helmreleases.helm.toolkit.fluxcd.io
+  name: crdupgradetestbs.crd-upgrades.helmreleases.cd.qdrant.io
 spec:
-  group: crd-upgrades.helmreleases.helm.toolkit.fluxcd.io
+  group: crd-upgrades.helmreleases.cd.qdrant.io
   names:
     kind: CrdUpgradeTestb
     listKind: CrdUpgradeTestbList

--- a/config/testdata/charts/crds/v2/crds/c.yaml
+++ b/config/testdata/charts/crds/v2/crds/c.yaml
@@ -3,9 +3,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: crdupgradetestcs.crd-upgrades.helmreleases.helm.toolkit.fluxcd.io
+  name: crdupgradetestcs.crd-upgrades.helmreleases.cd.qdrant.io
 spec:
-  group: crd-upgrades.helmreleases.helm.toolkit.fluxcd.io
+  group: crd-upgrades.helmreleases.cd.qdrant.io
   names:
     kind: CrdUpgradeTestc
     listKind: CrdUpgradeTestcList

--- a/config/testdata/charts/crds/v2/templates/dummy.yaml
+++ b/config/testdata/charts/crds/v2/templates/dummy.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.a }}
 ---
 kind: CrdUpgradeTesta
-apiVersion: crd-upgrades.helmreleases.helm.toolkit.fluxcd.io/{{.Values.a}}
+apiVersion: crd-upgrades.helmreleases.cd.qdrant.io/{{.Values.a}}
 metadata:
   name: a
 spec: {}
@@ -9,7 +9,7 @@ spec: {}
 {{- if .Values.b }}
 ---
 kind: CrdUpgradeTestb
-apiVersion: crd-upgrades.helmreleases.helm.toolkit.fluxcd.io/{{.Values.b}}
+apiVersion: crd-upgrades.helmreleases.cd.qdrant.io/{{.Values.b}}
 metadata:
   name: b
 spec: {}
@@ -17,7 +17,7 @@ spec: {}
 {{- if .Values.c }}
 ---
 kind: CrdUpgradeTestc
-apiVersion: crd-upgrades.helmreleases.helm.toolkit.fluxcd.io/{{.Values.c}}
+apiVersion: crd-upgrades.helmreleases.cd.qdrant.io/{{.Values.c}}
 metadata:
   name: c
 spec: {}
@@ -25,7 +25,7 @@ spec: {}
 {{- if .Values.d }}
 ---
 kind: CrdUpgradeTestd
-apiVersion: crd-upgrades.helmreleases.helm.toolkit.fluxcd.io/{{.Values.d}}
+apiVersion: crd-upgrades.helmreleases.cd.qdrant.io/{{.Values.d}}
 metadata:
   name: d
 spec: {}

--- a/config/testdata/crds-upgrade/create-replace/helmrelease.yaml
+++ b/config/testdata/crds-upgrade/create-replace/helmrelease.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: crds-upgrade-test

--- a/config/testdata/crds-upgrade/create/helmrelease.yaml
+++ b/config/testdata/crds-upgrade/create/helmrelease.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: crds-upgrade-test

--- a/config/testdata/crds-upgrade/init/helmrelease.yaml
+++ b/config/testdata/crds-upgrade/init/helmrelease.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: crds-upgrade-test

--- a/config/testdata/delete-ns/test.yaml
+++ b/config/testdata/delete-ns/test.yaml
@@ -42,7 +42,7 @@ subjects:
     name: gotk-reconciler
     namespace: delete-ns
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: HelmRepository
 metadata:
   name: podinfo
@@ -51,7 +51,7 @@ spec:
   interval: 1m
   url: https://stefanprodan.github.io/podinfo
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: podinfo

--- a/config/testdata/dependencies/helmrelease-backend.yaml
+++ b/config/testdata/dependencies/helmrelease-backend.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: backend

--- a/config/testdata/dependencies/helmrelease-frontend.yaml
+++ b/config/testdata/dependencies/helmrelease-frontend.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: frontend

--- a/config/testdata/impersonation/test.yaml
+++ b/config/testdata/impersonation/test.yaml
@@ -42,7 +42,7 @@ subjects:
     name: gotk-reconciler
     namespace: impersonation
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: HelmRepository
 metadata:
   name: podinfo
@@ -51,7 +51,7 @@ spec:
   interval: 1m
   url: https://stefanprodan.github.io/podinfo
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: podinfo
@@ -67,7 +67,7 @@ spec:
         kind: HelmRepository
         name: podinfo
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: podinfo-fail

--- a/config/testdata/install-create-target-ns/helmrelease.yaml
+++ b/config/testdata/install-create-target-ns/helmrelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: install-create-target-ns

--- a/config/testdata/install-fail-remediate/helmrelease.yaml
+++ b/config/testdata/install-fail-remediate/helmrelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: install-fail-remediate

--- a/config/testdata/install-fail-retry/helmrelease.yaml
+++ b/config/testdata/install-fail-retry/helmrelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: install-fail-retry

--- a/config/testdata/install-fail/helmrelease.yaml
+++ b/config/testdata/install-fail/helmrelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: install-fail

--- a/config/testdata/install-from-hc-source/test.yaml
+++ b/config/testdata/install-from-hc-source/test.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: HelmChart
 metadata:
   name: podinfo-hc
@@ -13,7 +13,7 @@ spec:
   verify:
     provider: cosign
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: podinfo-from-hc

--- a/config/testdata/install-from-ocirepo-source/test.yaml
+++ b/config/testdata/install-from-ocirepo-source/test.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: OCIRepository
 metadata:
   name: podinfo-ocirepo
@@ -9,7 +9,7 @@ spec:
   ref:
     tag: 6.6.0
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: podinfo-from-ocirepo

--- a/config/testdata/install-test-fail-ignore/helmrelease.yaml
+++ b/config/testdata/install-test-fail-ignore/helmrelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: install-test-fail-ignore

--- a/config/testdata/install-test-fail/helmrelease.yaml
+++ b/config/testdata/install-test-fail/helmrelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: install-test-fail

--- a/config/testdata/podinfo/helmrelease-git.yaml
+++ b/config/testdata/podinfo/helmrelease-git.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: podinfo-git

--- a/config/testdata/podinfo/helmrelease-oci.yaml
+++ b/config/testdata/podinfo/helmrelease-oci.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: podinfo-oci

--- a/config/testdata/podinfo/helmrelease.yaml
+++ b/config/testdata/podinfo/helmrelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: podinfo

--- a/config/testdata/post-renderer-kustomize/helmrelease.yaml
+++ b/config/testdata/post-renderer-kustomize/helmrelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: post-renderer-kustomize

--- a/config/testdata/sources/gitrepository.yaml
+++ b/config/testdata/sources/gitrepository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: GitRepository
 metadata:
   name: podinfo

--- a/config/testdata/sources/helmrepository.yaml
+++ b/config/testdata/sources/helmrepository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: HelmRepository
 metadata:
   name: podinfo

--- a/config/testdata/sources/helmrepository_oci.yaml
+++ b/config/testdata/sources/helmrepository_oci.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: HelmRepository
 metadata:
   name: podinfo-oci

--- a/config/testdata/status-defaults/helmrelease.yaml
+++ b/config/testdata/status-defaults/helmrelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: status-defaults

--- a/config/testdata/targetnamespace/helmrelease.yaml
+++ b/config/testdata/targetnamespace/helmrelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: targetnamespace

--- a/config/testdata/upgrade-fail-remediate-uninstall/install.yaml
+++ b/config/testdata/upgrade-fail-remediate-uninstall/install.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: upgrade-fail-remediate-uninstall

--- a/config/testdata/upgrade-fail-remediate-uninstall/upgrade.yaml
+++ b/config/testdata/upgrade-fail-remediate-uninstall/upgrade.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: upgrade-fail-remediate-uninstall

--- a/config/testdata/upgrade-fail-remediate/install.yaml
+++ b/config/testdata/upgrade-fail-remediate/install.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: upgrade-fail-remediate

--- a/config/testdata/upgrade-fail-remediate/upgrade.yaml
+++ b/config/testdata/upgrade-fail-remediate/upgrade.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: upgrade-fail-remediate

--- a/config/testdata/upgrade-fail-retry/install.yaml
+++ b/config/testdata/upgrade-fail-retry/install.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: upgrade-fail-retry

--- a/config/testdata/upgrade-fail-retry/upgrade.yaml
+++ b/config/testdata/upgrade-fail-retry/upgrade.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: upgrade-fail-retry

--- a/config/testdata/upgrade-fail/install.yaml
+++ b/config/testdata/upgrade-fail/install.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: upgrade-fail

--- a/config/testdata/upgrade-fail/upgrade.yaml
+++ b/config/testdata/upgrade-fail/upgrade.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: upgrade-fail

--- a/config/testdata/upgrade-from-ocirepo-source/install.yaml
+++ b/config/testdata/upgrade-from-ocirepo-source/install.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: OCIRepository
 metadata:
   name: upgrade-from-ocirepo-source
@@ -9,7 +9,7 @@ spec:
   ref:
     digest: "sha256:cdd538a0167e4b51152b71a477e51eb6737553510ce8797dbcc537e1342311bb"
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: upgrade-from-ocirepo-source

--- a/config/testdata/upgrade-from-ocirepo-source/upgrade.yaml
+++ b/config/testdata/upgrade-from-ocirepo-source/upgrade.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: OCIRepository
 metadata:
   name: upgrade-from-ocirepo-source

--- a/config/testdata/upgrade-test-fail/install.yaml
+++ b/config/testdata/upgrade-test-fail/install.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: upgrade-test-fail

--- a/config/testdata/upgrade-test-fail/upgrade.yaml
+++ b/config/testdata/upgrade-test-fail/upgrade.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: upgrade-test-fail

--- a/config/testdata/valuesfrom/helmrelease.yaml
+++ b/config/testdata/valuesfrom/helmrelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: valuesfrom

--- a/docs/api/v2/helm.md
+++ b/docs/api/v2/helm.md
@@ -2,16 +2,16 @@
 <p>Packages:</p>
 <ul class="simple">
 <li>
-<a href="#helm.toolkit.fluxcd.io%2fv2">helm.toolkit.fluxcd.io/v2</a>
+<a href="#cd.qdrant.io%2fv2">cd.qdrant.io/v2</a>
 </li>
 </ul>
-<h2 id="helm.toolkit.fluxcd.io/v2">helm.toolkit.fluxcd.io/v2</h2>
+<h2 id="cd.qdrant.io/v2">cd.qdrant.io/v2</h2>
 <p>Package v2 contains API Schema definitions for the helm v2 API group</p>
 Resource Types:
 <ul class="simple"><li>
-<a href="#helm.toolkit.fluxcd.io/v2.HelmRelease">HelmRelease</a>
+<a href="#cd.qdrant.io/v2.HelmRelease">HelmRelease</a>
 </li></ul>
-<h3 id="helm.toolkit.fluxcd.io/v2.HelmRelease">HelmRelease
+<h3 id="cd.qdrant.io/v2.HelmRelease">HelmRelease
 </h3>
 <p>HelmRelease is the Schema for the helmreleases API</p>
 <div class="md-typeset__scrollwrap">
@@ -29,7 +29,7 @@ Resource Types:
 <code>apiVersion</code><br>
 string</td>
 <td>
-<code>helm.toolkit.fluxcd.io/v2</code>
+<code>cd.qdrant.io/v2</code>
 </td>
 </tr>
 <tr>
@@ -59,7 +59,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2.HelmReleaseSpec">
+<a href="#cd.qdrant.io/v2.HelmReleaseSpec">
 HelmReleaseSpec
 </a>
 </em>
@@ -72,7 +72,7 @@ HelmReleaseSpec
 <td>
 <code>chart</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2.HelmChartTemplate">
+<a href="#cd.qdrant.io/v2.HelmChartTemplate">
 HelmChartTemplate
 </a>
 </em>
@@ -87,7 +87,7 @@ for this HelmRelease.</p>
 <td>
 <code>chartRef</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2.CrossNamespaceSourceReference">
+<a href="#cd.qdrant.io/v2.CrossNamespaceSourceReference">
 CrossNamespaceSourceReference
 </a>
 </em>
@@ -264,7 +264,7 @@ available by e.g. post-install hooks.</p>
 <td>
 <code>driftDetection</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2.DriftDetection">
+<a href="#cd.qdrant.io/v2.DriftDetection">
 DriftDetection
 </a>
 </em>
@@ -280,7 +280,7 @@ currently existing in the cluster.</p>
 <td>
 <code>install</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2.Install">
+<a href="#cd.qdrant.io/v2.Install">
 Install
 </a>
 </em>
@@ -294,7 +294,7 @@ Install
 <td>
 <code>upgrade</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2.Upgrade">
+<a href="#cd.qdrant.io/v2.Upgrade">
 Upgrade
 </a>
 </em>
@@ -308,7 +308,7 @@ Upgrade
 <td>
 <code>test</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2.Test">
+<a href="#cd.qdrant.io/v2.Test">
 Test
 </a>
 </em>
@@ -322,7 +322,7 @@ Test
 <td>
 <code>rollback</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2.Rollback">
+<a href="#cd.qdrant.io/v2.Rollback">
 Rollback
 </a>
 </em>
@@ -336,7 +336,7 @@ Rollback
 <td>
 <code>uninstall</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2.Uninstall">
+<a href="#cd.qdrant.io/v2.Uninstall">
 Uninstall
 </a>
 </em>
@@ -350,7 +350,7 @@ Uninstall
 <td>
 <code>valuesFrom</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2.ValuesReference">
+<a href="#cd.qdrant.io/v2.ValuesReference">
 []ValuesReference
 </a>
 </em>
@@ -378,7 +378,7 @@ Kubernetes pkg/apis/apiextensions/v1.JSON
 <td>
 <code>postRenderers</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2.PostRenderer">
+<a href="#cd.qdrant.io/v2.PostRenderer">
 []PostRenderer
 </a>
 </em>
@@ -396,7 +396,7 @@ of their definition.</p>
 <td>
 <code>status</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2.HelmReleaseStatus">
+<a href="#cd.qdrant.io/v2.HelmReleaseStatus">
 HelmReleaseStatus
 </a>
 </em>
@@ -408,20 +408,20 @@ HelmReleaseStatus
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2.CRDsPolicy">CRDsPolicy
+<h3 id="cd.qdrant.io/v2.CRDsPolicy">CRDsPolicy
 (<code>string</code> alias)</h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2.Install">Install</a>, 
-<a href="#helm.toolkit.fluxcd.io/v2.Upgrade">Upgrade</a>)
+<a href="#cd.qdrant.io/v2.Install">Install</a>, 
+<a href="#cd.qdrant.io/v2.Upgrade">Upgrade</a>)
 </p>
 <p>CRDsPolicy defines the install/upgrade approach to use for CRDs when
 installing or upgrading a HelmRelease.</p>
-<h3 id="helm.toolkit.fluxcd.io/v2.CrossNamespaceObjectReference">CrossNamespaceObjectReference
+<h3 id="cd.qdrant.io/v2.CrossNamespaceObjectReference">CrossNamespaceObjectReference
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2.HelmChartTemplateSpec">HelmChartTemplateSpec</a>)
+<a href="#cd.qdrant.io/v2.HelmChartTemplateSpec">HelmChartTemplateSpec</a>)
 </p>
 <p>CrossNamespaceObjectReference contains enough information to let you locate
 the typed referenced object at cluster level.</p>
@@ -485,11 +485,11 @@ string
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2.CrossNamespaceSourceReference">CrossNamespaceSourceReference
+<h3 id="cd.qdrant.io/v2.CrossNamespaceSourceReference">CrossNamespaceSourceReference
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2.HelmReleaseSpec">HelmReleaseSpec</a>)
+<a href="#cd.qdrant.io/v2.HelmReleaseSpec">HelmReleaseSpec</a>)
 </p>
 <p>CrossNamespaceSourceReference contains enough information to let you locate
 the typed referenced object at cluster level.</p>
@@ -554,11 +554,11 @@ resource object that contains the reference.</p>
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2.DriftDetection">DriftDetection
+<h3 id="cd.qdrant.io/v2.DriftDetection">DriftDetection
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2.HelmReleaseSpec">HelmReleaseSpec</a>)
+<a href="#cd.qdrant.io/v2.HelmReleaseSpec">HelmReleaseSpec</a>)
 </p>
 <p>DriftDetection defines the strategy for performing differential analysis and
 provides a way to define rules for ignoring specific changes during this
@@ -577,7 +577,7 @@ process.</p>
 <td>
 <code>mode</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2.DriftDetectionMode">
+<a href="#cd.qdrant.io/v2.DriftDetectionMode">
 DriftDetectionMode
 </a>
 </em>
@@ -593,7 +593,7 @@ If not explicitly set, it defaults to DiffModeDisabled.</p>
 <td>
 <code>ignore</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2.IgnoreRule">
+<a href="#cd.qdrant.io/v2.IgnoreRule">
 []IgnoreRule
 </a>
 </em>
@@ -608,20 +608,20 @@ during diffing.</p>
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2.DriftDetectionMode">DriftDetectionMode
+<h3 id="cd.qdrant.io/v2.DriftDetectionMode">DriftDetectionMode
 (<code>string</code> alias)</h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2.DriftDetection">DriftDetection</a>)
+<a href="#cd.qdrant.io/v2.DriftDetection">DriftDetection</a>)
 </p>
 <p>DriftDetectionMode represents the modes in which a controller can detect and
 handle differences between the manifest in the Helm storage and the resources
 currently existing in the cluster.</p>
-<h3 id="helm.toolkit.fluxcd.io/v2.Filter">Filter
+<h3 id="cd.qdrant.io/v2.Filter">Filter
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2.Test">Test</a>)
+<a href="#cd.qdrant.io/v2.Test">Test</a>)
 </p>
 <p>Filter holds the configuration for individual Helm test filters.</p>
 <div class="md-typeset__scrollwrap">
@@ -661,11 +661,11 @@ bool
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2.HelmChartTemplate">HelmChartTemplate
+<h3 id="cd.qdrant.io/v2.HelmChartTemplate">HelmChartTemplate
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2.HelmReleaseSpec">HelmReleaseSpec</a>)
+<a href="#cd.qdrant.io/v2.HelmReleaseSpec">HelmReleaseSpec</a>)
 </p>
 <p>HelmChartTemplate defines the template from which the controller will
 generate a v1.HelmChart object in the same namespace as the referenced
@@ -684,7 +684,7 @@ v1.Source.</p>
 <td>
 <code>metadata</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2.HelmChartTemplateObjectMeta">
+<a href="#cd.qdrant.io/v2.HelmChartTemplateObjectMeta">
 HelmChartTemplateObjectMeta
 </a>
 </em>
@@ -698,7 +698,7 @@ HelmChartTemplateObjectMeta
 <td>
 <code>spec</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2.HelmChartTemplateSpec">
+<a href="#cd.qdrant.io/v2.HelmChartTemplateSpec">
 HelmChartTemplateSpec
 </a>
 </em>
@@ -736,7 +736,7 @@ v1beta2.Bucket sources. Defaults to latest when omitted.</p>
 <td>
 <code>sourceRef</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2.CrossNamespaceObjectReference">
+<a href="#cd.qdrant.io/v2.CrossNamespaceObjectReference">
 CrossNamespaceObjectReference
 </a>
 </em>
@@ -806,7 +806,7 @@ bool
 <td>
 <code>verify</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2.HelmChartTemplateVerification">
+<a href="#cd.qdrant.io/v2.HelmChartTemplateVerification">
 HelmChartTemplateVerification
 </a>
 </em>
@@ -828,11 +828,11 @@ are not verified.</p>
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2.HelmChartTemplateObjectMeta">HelmChartTemplateObjectMeta
+<h3 id="cd.qdrant.io/v2.HelmChartTemplateObjectMeta">HelmChartTemplateObjectMeta
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2.HelmChartTemplate">HelmChartTemplate</a>)
+<a href="#cd.qdrant.io/v2.HelmChartTemplate">HelmChartTemplate</a>)
 </p>
 <p>HelmChartTemplateObjectMeta defines the template for the ObjectMeta of a
 v1.HelmChart.</p>
@@ -879,11 +879,11 @@ More info: <a href="https://kubernetes.io/docs/concepts/overview/working-with-ob
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2.HelmChartTemplateSpec">HelmChartTemplateSpec
+<h3 id="cd.qdrant.io/v2.HelmChartTemplateSpec">HelmChartTemplateSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2.HelmChartTemplate">HelmChartTemplate</a>)
+<a href="#cd.qdrant.io/v2.HelmChartTemplate">HelmChartTemplate</a>)
 </p>
 <p>HelmChartTemplateSpec defines the template from which the controller will
 generate a v1.HelmChartSpec object.</p>
@@ -925,7 +925,7 @@ v1beta2.Bucket sources. Defaults to latest when omitted.</p>
 <td>
 <code>sourceRef</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2.CrossNamespaceObjectReference">
+<a href="#cd.qdrant.io/v2.CrossNamespaceObjectReference">
 CrossNamespaceObjectReference
 </a>
 </em>
@@ -995,7 +995,7 @@ bool
 <td>
 <code>verify</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2.HelmChartTemplateVerification">
+<a href="#cd.qdrant.io/v2.HelmChartTemplateVerification">
 HelmChartTemplateVerification
 </a>
 </em>
@@ -1014,11 +1014,11 @@ are not verified.</p>
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2.HelmChartTemplateVerification">HelmChartTemplateVerification
+<h3 id="cd.qdrant.io/v2.HelmChartTemplateVerification">HelmChartTemplateVerification
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2.HelmChartTemplateSpec">HelmChartTemplateSpec</a>)
+<a href="#cd.qdrant.io/v2.HelmChartTemplateSpec">HelmChartTemplateSpec</a>)
 </p>
 <p>HelmChartTemplateVerification verifies the authenticity of an OCI Helm chart.</p>
 <div class="md-typeset__scrollwrap">
@@ -1061,11 +1061,11 @@ trusted public keys.</p>
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2.HelmReleaseSpec">HelmReleaseSpec
+<h3 id="cd.qdrant.io/v2.HelmReleaseSpec">HelmReleaseSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2.HelmRelease">HelmRelease</a>)
+<a href="#cd.qdrant.io/v2.HelmRelease">HelmRelease</a>)
 </p>
 <p>HelmReleaseSpec defines the desired state of a Helm release.</p>
 <div class="md-typeset__scrollwrap">
@@ -1082,7 +1082,7 @@ trusted public keys.</p>
 <td>
 <code>chart</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2.HelmChartTemplate">
+<a href="#cd.qdrant.io/v2.HelmChartTemplate">
 HelmChartTemplate
 </a>
 </em>
@@ -1097,7 +1097,7 @@ for this HelmRelease.</p>
 <td>
 <code>chartRef</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2.CrossNamespaceSourceReference">
+<a href="#cd.qdrant.io/v2.CrossNamespaceSourceReference">
 CrossNamespaceSourceReference
 </a>
 </em>
@@ -1274,7 +1274,7 @@ available by e.g. post-install hooks.</p>
 <td>
 <code>driftDetection</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2.DriftDetection">
+<a href="#cd.qdrant.io/v2.DriftDetection">
 DriftDetection
 </a>
 </em>
@@ -1290,7 +1290,7 @@ currently existing in the cluster.</p>
 <td>
 <code>install</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2.Install">
+<a href="#cd.qdrant.io/v2.Install">
 Install
 </a>
 </em>
@@ -1304,7 +1304,7 @@ Install
 <td>
 <code>upgrade</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2.Upgrade">
+<a href="#cd.qdrant.io/v2.Upgrade">
 Upgrade
 </a>
 </em>
@@ -1318,7 +1318,7 @@ Upgrade
 <td>
 <code>test</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2.Test">
+<a href="#cd.qdrant.io/v2.Test">
 Test
 </a>
 </em>
@@ -1332,7 +1332,7 @@ Test
 <td>
 <code>rollback</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2.Rollback">
+<a href="#cd.qdrant.io/v2.Rollback">
 Rollback
 </a>
 </em>
@@ -1346,7 +1346,7 @@ Rollback
 <td>
 <code>uninstall</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2.Uninstall">
+<a href="#cd.qdrant.io/v2.Uninstall">
 Uninstall
 </a>
 </em>
@@ -1360,7 +1360,7 @@ Uninstall
 <td>
 <code>valuesFrom</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2.ValuesReference">
+<a href="#cd.qdrant.io/v2.ValuesReference">
 []ValuesReference
 </a>
 </em>
@@ -1388,7 +1388,7 @@ Kubernetes pkg/apis/apiextensions/v1.JSON
 <td>
 <code>postRenderers</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2.PostRenderer">
+<a href="#cd.qdrant.io/v2.PostRenderer">
 []PostRenderer
 </a>
 </em>
@@ -1403,11 +1403,11 @@ of their definition.</p>
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2.HelmReleaseStatus">HelmReleaseStatus
+<h3 id="cd.qdrant.io/v2.HelmReleaseStatus">HelmReleaseStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2.HelmRelease">HelmRelease</a>)
+<a href="#cd.qdrant.io/v2.HelmRelease">HelmRelease</a>)
 </p>
 <p>HelmReleaseStatus defines the observed state of a HelmRelease.</p>
 <div class="md-typeset__scrollwrap">
@@ -1502,7 +1502,7 @@ current release.</p>
 <td>
 <code>history</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2.Snapshots">
+<a href="#cd.qdrant.io/v2.Snapshots">
 Snapshots
 </a>
 </em>
@@ -1517,7 +1517,7 @@ up to the last successfully completed release.</p>
 <td>
 <code>lastAttemptedReleaseAction</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2.ReleaseAction">
+<a href="#cd.qdrant.io/v2.ReleaseAction">
 ReleaseAction
 </a>
 </em>
@@ -1679,11 +1679,11 @@ github.com/fluxcd/pkg/apis/meta.ReconcileRequestStatus
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2.IgnoreRule">IgnoreRule
+<h3 id="cd.qdrant.io/v2.IgnoreRule">IgnoreRule
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2.DriftDetection">DriftDetection</a>)
+<a href="#cd.qdrant.io/v2.DriftDetection">DriftDetection</a>)
 </p>
 <p>IgnoreRule defines a rule to selectively disregard specific changes during
 the drift detection process.</p>
@@ -1730,11 +1730,11 @@ objects within the manifest of the Helm release.</p>
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2.Install">Install
+<h3 id="cd.qdrant.io/v2.Install">Install
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2.HelmReleaseSpec">HelmReleaseSpec</a>)
+<a href="#cd.qdrant.io/v2.HelmReleaseSpec">HelmReleaseSpec</a>)
 </p>
 <p>Install holds the configuration for Helm install actions performed for this
 HelmRelease.</p>
@@ -1768,7 +1768,7 @@ Jobs for hooks) during the performance of a Helm install action. Defaults to
 <td>
 <code>remediation</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2.InstallRemediation">
+<a href="#cd.qdrant.io/v2.InstallRemediation">
 InstallRemediation
 </a>
 </em>
@@ -1861,7 +1861,7 @@ CRDs are installed if not already present.</p>
 <td>
 <code>crds</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2.CRDsPolicy">
+<a href="#cd.qdrant.io/v2.CRDsPolicy">
 CRDsPolicy
 </a>
 </em>
@@ -1900,11 +1900,11 @@ On uninstall, the namespace will not be garbage collected.</p>
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2.InstallRemediation">InstallRemediation
+<h3 id="cd.qdrant.io/v2.InstallRemediation">InstallRemediation
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2.Install">Install</a>)
+<a href="#cd.qdrant.io/v2.Install">Install</a>)
 </p>
 <p>InstallRemediation holds the configuration for Helm install remediation.</p>
 <div class="md-typeset__scrollwrap">
@@ -1962,11 +1962,11 @@ no retries remain. Defaults to &lsquo;false&rsquo;.</p>
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2.Kustomize">Kustomize
+<h3 id="cd.qdrant.io/v2.Kustomize">Kustomize
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2.PostRenderer">PostRenderer</a>)
+<a href="#cd.qdrant.io/v2.PostRenderer">PostRenderer</a>)
 </p>
 <p>Kustomize Helm PostRenderer specification.</p>
 <div class="md-typeset__scrollwrap">
@@ -2014,11 +2014,11 @@ patch, but this operator is simpler to specify.</p>
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2.PostRenderer">PostRenderer
+<h3 id="cd.qdrant.io/v2.PostRenderer">PostRenderer
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2.HelmReleaseSpec">HelmReleaseSpec</a>)
+<a href="#cd.qdrant.io/v2.HelmReleaseSpec">HelmReleaseSpec</a>)
 </p>
 <p>PostRenderer contains a Helm PostRenderer specification.</p>
 <div class="md-typeset__scrollwrap">
@@ -2035,7 +2035,7 @@ patch, but this operator is simpler to specify.</p>
 <td>
 <code>kustomize</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2.Kustomize">
+<a href="#cd.qdrant.io/v2.Kustomize">
 Kustomize
 </a>
 </em>
@@ -2049,30 +2049,30 @@ Kustomize
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2.ReleaseAction">ReleaseAction
+<h3 id="cd.qdrant.io/v2.ReleaseAction">ReleaseAction
 (<code>string</code> alias)</h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2.HelmReleaseStatus">HelmReleaseStatus</a>)
+<a href="#cd.qdrant.io/v2.HelmReleaseStatus">HelmReleaseStatus</a>)
 </p>
 <p>ReleaseAction is the action to perform a Helm release.</p>
-<h3 id="helm.toolkit.fluxcd.io/v2.Remediation">Remediation
+<h3 id="cd.qdrant.io/v2.Remediation">Remediation
 </h3>
 <p>Remediation defines a consistent interface for InstallRemediation and
 UpgradeRemediation.</p>
-<h3 id="helm.toolkit.fluxcd.io/v2.RemediationStrategy">RemediationStrategy
+<h3 id="cd.qdrant.io/v2.RemediationStrategy">RemediationStrategy
 (<code>string</code> alias)</h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2.UpgradeRemediation">UpgradeRemediation</a>)
+<a href="#cd.qdrant.io/v2.UpgradeRemediation">UpgradeRemediation</a>)
 </p>
 <p>RemediationStrategy returns the strategy to use to remediate a failed install
 or upgrade.</p>
-<h3 id="helm.toolkit.fluxcd.io/v2.Rollback">Rollback
+<h3 id="cd.qdrant.io/v2.Rollback">Rollback
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2.HelmReleaseSpec">HelmReleaseSpec</a>)
+<a href="#cd.qdrant.io/v2.HelmReleaseSpec">HelmReleaseSpec</a>)
 </p>
 <p>Rollback holds the configuration for Helm rollback actions for this
 HelmRelease.</p>
@@ -2181,7 +2181,7 @@ rollback action when it fails.</p>
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2.Snapshot">Snapshot
+<h3 id="cd.qdrant.io/v2.Snapshot">Snapshot
 </h3>
 <p>Snapshot captures a point-in-time copy of the status information for a Helm release,
 as managed by the controller.</p>
@@ -2357,7 +2357,7 @@ Kubernetes meta/v1.Time
 <td>
 <code>testHooks</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2.TestHookStatus">
+<a href="#cd.qdrant.io/v2.TestHookStatus">
 TestHookStatus
 </a>
 </em>
@@ -2384,18 +2384,18 @@ string
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2.Snapshots">Snapshots
+<h3 id="cd.qdrant.io/v2.Snapshots">Snapshots
 (<code>[]*./api/v2.Snapshot</code> alias)</h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2.HelmReleaseStatus">HelmReleaseStatus</a>)
+<a href="#cd.qdrant.io/v2.HelmReleaseStatus">HelmReleaseStatus</a>)
 </p>
 <p>Snapshots is a list of Snapshot objects.</p>
-<h3 id="helm.toolkit.fluxcd.io/v2.Test">Test
+<h3 id="cd.qdrant.io/v2.Test">Test
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2.HelmReleaseSpec">HelmReleaseSpec</a>)
+<a href="#cd.qdrant.io/v2.HelmReleaseSpec">HelmReleaseSpec</a>)
 </p>
 <p>Test holds the configuration for Helm test actions for this HelmRelease.</p>
 <div class="md-typeset__scrollwrap">
@@ -2454,7 +2454,7 @@ actions in &lsquo;Install.IgnoreTestFailures&rsquo; and &lsquo;Upgrade.IgnoreTes
 <td>
 <code>filters</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2.Filter">
+<a href="#cd.qdrant.io/v2.Filter">
 Filter
 </a>
 </em>
@@ -2467,11 +2467,11 @@ Filter
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2.TestHookStatus">TestHookStatus
+<h3 id="cd.qdrant.io/v2.TestHookStatus">TestHookStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2.Snapshot">Snapshot</a>)
+<a href="#cd.qdrant.io/v2.Snapshot">Snapshot</a>)
 </p>
 <p>TestHookStatus holds the status information for a test hook as observed
 to be run by the controller.</p>
@@ -2529,11 +2529,11 @@ string
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2.Uninstall">Uninstall
+<h3 id="cd.qdrant.io/v2.Uninstall">Uninstall
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2.HelmReleaseSpec">HelmReleaseSpec</a>)
+<a href="#cd.qdrant.io/v2.HelmReleaseSpec">HelmReleaseSpec</a>)
 </p>
 <p>Uninstall holds the configuration for Helm uninstall actions for this
 HelmRelease.</p>
@@ -2618,11 +2618,11 @@ a Helm uninstall is performed.</p>
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2.Upgrade">Upgrade
+<h3 id="cd.qdrant.io/v2.Upgrade">Upgrade
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2.HelmReleaseSpec">HelmReleaseSpec</a>)
+<a href="#cd.qdrant.io/v2.HelmReleaseSpec">HelmReleaseSpec</a>)
 </p>
 <p>Upgrade holds the configuration for Helm upgrade actions for this
 HelmRelease.</p>
@@ -2656,7 +2656,7 @@ Jobs for hooks) during the performance of a Helm upgrade action. Defaults to
 <td>
 <code>remediation</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2.UpgradeRemediation">
+<a href="#cd.qdrant.io/v2.UpgradeRemediation">
 UpgradeRemediation
 </a>
 </em>
@@ -2761,7 +2761,7 @@ upgrade action when it fails.</p>
 <td>
 <code>crds</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2.CRDsPolicy">
+<a href="#cd.qdrant.io/v2.CRDsPolicy">
 CRDsPolicy
 </a>
 </em>
@@ -2785,11 +2785,11 @@ option users can opt-in to CRD upgrade, which is not (yet) natively supported by
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2.UpgradeRemediation">UpgradeRemediation
+<h3 id="cd.qdrant.io/v2.UpgradeRemediation">UpgradeRemediation
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2.Upgrade">Upgrade</a>)
+<a href="#cd.qdrant.io/v2.Upgrade">Upgrade</a>)
 </p>
 <p>UpgradeRemediation holds the configuration for Helm upgrade remediation.</p>
 <div class="md-typeset__scrollwrap">
@@ -2847,7 +2847,7 @@ no retries remain. Defaults to &lsquo;false&rsquo; unless &lsquo;Retries&rsquo; 
 <td>
 <code>strategy</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2.RemediationStrategy">
+<a href="#cd.qdrant.io/v2.RemediationStrategy">
 RemediationStrategy
 </a>
 </em>
@@ -2861,11 +2861,11 @@ RemediationStrategy
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2.ValuesReference">ValuesReference
+<h3 id="cd.qdrant.io/v2.ValuesReference">ValuesReference
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2.HelmReleaseSpec">HelmReleaseSpec</a>)
+<a href="#cd.qdrant.io/v2.HelmReleaseSpec">HelmReleaseSpec</a>)
 </p>
 <p>ValuesReference contains a reference to a resource containing Helm values,
 and optionally the key they can be found at.</p>

--- a/docs/api/v2beta1/helm.md
+++ b/docs/api/v2beta1/helm.md
@@ -2,16 +2,16 @@
 <p>Packages:</p>
 <ul class="simple">
 <li>
-<a href="#helm.toolkit.fluxcd.io%2fv2beta1">helm.toolkit.fluxcd.io/v2beta1</a>
+<a href="#cd.qdrant.io%2fv2beta1">cd.qdrant.io/v2beta1</a>
 </li>
 </ul>
-<h2 id="helm.toolkit.fluxcd.io/v2beta1">helm.toolkit.fluxcd.io/v2beta1</h2>
+<h2 id="cd.qdrant.io/v2beta1">cd.qdrant.io/v2beta1</h2>
 <p>Package v2beta1 contains API Schema definitions for the helm v2beta1 API group</p>
 Resource Types:
 <ul class="simple"><li>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.HelmRelease">HelmRelease</a>
+<a href="#cd.qdrant.io/v2beta1.HelmRelease">HelmRelease</a>
 </li></ul>
-<h3 id="helm.toolkit.fluxcd.io/v2beta1.HelmRelease">HelmRelease
+<h3 id="cd.qdrant.io/v2beta1.HelmRelease">HelmRelease
 </h3>
 <p>HelmRelease is the Schema for the helmreleases API</p>
 <div class="md-typeset__scrollwrap">
@@ -29,7 +29,7 @@ Resource Types:
 <code>apiVersion</code><br>
 string</td>
 <td>
-<code>helm.toolkit.fluxcd.io/v2beta1</code>
+<code>cd.qdrant.io/v2beta1</code>
 </td>
 </tr>
 <tr>
@@ -59,7 +59,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.HelmReleaseSpec">
+<a href="#cd.qdrant.io/v2beta1.HelmReleaseSpec">
 HelmReleaseSpec
 </a>
 </em>
@@ -72,7 +72,7 @@ HelmReleaseSpec
 <td>
 <code>chart</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.HelmChartTemplate">
+<a href="#cd.qdrant.io/v2beta1.HelmChartTemplate">
 HelmChartTemplate
 </a>
 </em>
@@ -250,7 +250,7 @@ available by e.g. post-install hooks.</p>
 <td>
 <code>install</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.Install">
+<a href="#cd.qdrant.io/v2beta1.Install">
 Install
 </a>
 </em>
@@ -264,7 +264,7 @@ Install
 <td>
 <code>upgrade</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.Upgrade">
+<a href="#cd.qdrant.io/v2beta1.Upgrade">
 Upgrade
 </a>
 </em>
@@ -278,7 +278,7 @@ Upgrade
 <td>
 <code>test</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.Test">
+<a href="#cd.qdrant.io/v2beta1.Test">
 Test
 </a>
 </em>
@@ -292,7 +292,7 @@ Test
 <td>
 <code>rollback</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.Rollback">
+<a href="#cd.qdrant.io/v2beta1.Rollback">
 Rollback
 </a>
 </em>
@@ -306,7 +306,7 @@ Rollback
 <td>
 <code>uninstall</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.Uninstall">
+<a href="#cd.qdrant.io/v2beta1.Uninstall">
 Uninstall
 </a>
 </em>
@@ -320,7 +320,7 @@ Uninstall
 <td>
 <code>valuesFrom</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.ValuesReference">
+<a href="#cd.qdrant.io/v2beta1.ValuesReference">
 []ValuesReference
 </a>
 </em>
@@ -348,7 +348,7 @@ Kubernetes pkg/apis/apiextensions/v1.JSON
 <td>
 <code>postRenderers</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.PostRenderer">
+<a href="#cd.qdrant.io/v2beta1.PostRenderer">
 []PostRenderer
 </a>
 </em>
@@ -366,7 +366,7 @@ of their definition.</p>
 <td>
 <code>status</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.HelmReleaseStatus">
+<a href="#cd.qdrant.io/v2beta1.HelmReleaseStatus">
 HelmReleaseStatus
 </a>
 </em>
@@ -378,20 +378,20 @@ HelmReleaseStatus
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2beta1.CRDsPolicy">CRDsPolicy
+<h3 id="cd.qdrant.io/v2beta1.CRDsPolicy">CRDsPolicy
 (<code>string</code> alias)</h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.Install">Install</a>, 
-<a href="#helm.toolkit.fluxcd.io/v2beta1.Upgrade">Upgrade</a>)
+<a href="#cd.qdrant.io/v2beta1.Install">Install</a>, 
+<a href="#cd.qdrant.io/v2beta1.Upgrade">Upgrade</a>)
 </p>
 <p>CRDsPolicy defines the install/upgrade approach to use for CRDs when
 installing or upgrading a HelmRelease.</p>
-<h3 id="helm.toolkit.fluxcd.io/v2beta1.CrossNamespaceObjectReference">CrossNamespaceObjectReference
+<h3 id="cd.qdrant.io/v2beta1.CrossNamespaceObjectReference">CrossNamespaceObjectReference
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.HelmChartTemplateSpec">HelmChartTemplateSpec</a>)
+<a href="#cd.qdrant.io/v2beta1.HelmChartTemplateSpec">HelmChartTemplateSpec</a>)
 </p>
 <p>CrossNamespaceObjectReference contains enough information to let you locate
 the typed referenced object at cluster level.</p>
@@ -455,14 +455,14 @@ string
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2beta1.DeploymentAction">DeploymentAction
+<h3 id="cd.qdrant.io/v2beta1.DeploymentAction">DeploymentAction
 </h3>
 <p>DeploymentAction defines a consistent interface for Install and Upgrade.</p>
-<h3 id="helm.toolkit.fluxcd.io/v2beta1.HelmChartTemplate">HelmChartTemplate
+<h3 id="cd.qdrant.io/v2beta1.HelmChartTemplate">HelmChartTemplate
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.HelmReleaseSpec">HelmReleaseSpec</a>)
+<a href="#cd.qdrant.io/v2beta1.HelmReleaseSpec">HelmReleaseSpec</a>)
 </p>
 <p>HelmChartTemplate defines the template from which the controller will
 generate a v1beta2.HelmChart object in the same namespace as the referenced
@@ -481,7 +481,7 @@ v1beta2.Source.</p>
 <td>
 <code>metadata</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.HelmChartTemplateObjectMeta">
+<a href="#cd.qdrant.io/v2beta1.HelmChartTemplateObjectMeta">
 HelmChartTemplateObjectMeta
 </a>
 </em>
@@ -495,7 +495,7 @@ HelmChartTemplateObjectMeta
 <td>
 <code>spec</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.HelmChartTemplateSpec">
+<a href="#cd.qdrant.io/v2beta1.HelmChartTemplateSpec">
 HelmChartTemplateSpec
 </a>
 </em>
@@ -533,7 +533,7 @@ v1beta2.Bucket sources. Defaults to latest when omitted.</p>
 <td>
 <code>sourceRef</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.CrossNamespaceObjectReference">
+<a href="#cd.qdrant.io/v2beta1.CrossNamespaceObjectReference">
 CrossNamespaceObjectReference
 </a>
 </em>
@@ -606,7 +606,7 @@ ValuesFiles items. Ignored when omitted.</p>
 <td>
 <code>verify</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.HelmChartTemplateVerification">
+<a href="#cd.qdrant.io/v2beta1.HelmChartTemplateVerification">
 HelmChartTemplateVerification
 </a>
 </em>
@@ -627,11 +627,11 @@ Chart dependencies, which are not bundled in the umbrella chart artifact, are no
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2beta1.HelmChartTemplateObjectMeta">HelmChartTemplateObjectMeta
+<h3 id="cd.qdrant.io/v2beta1.HelmChartTemplateObjectMeta">HelmChartTemplateObjectMeta
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.HelmChartTemplate">HelmChartTemplate</a>)
+<a href="#cd.qdrant.io/v2beta1.HelmChartTemplate">HelmChartTemplate</a>)
 </p>
 <p>HelmChartTemplateObjectMeta defines the template for the ObjectMeta of a
 v1beta2.HelmChart.</p>
@@ -678,11 +678,11 @@ More info: <a href="https://kubernetes.io/docs/concepts/overview/working-with-ob
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2beta1.HelmChartTemplateSpec">HelmChartTemplateSpec
+<h3 id="cd.qdrant.io/v2beta1.HelmChartTemplateSpec">HelmChartTemplateSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.HelmChartTemplate">HelmChartTemplate</a>)
+<a href="#cd.qdrant.io/v2beta1.HelmChartTemplate">HelmChartTemplate</a>)
 </p>
 <p>HelmChartTemplateSpec defines the template from which the controller will
 generate a v1beta2.HelmChartSpec object.</p>
@@ -724,7 +724,7 @@ v1beta2.Bucket sources. Defaults to latest when omitted.</p>
 <td>
 <code>sourceRef</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.CrossNamespaceObjectReference">
+<a href="#cd.qdrant.io/v2beta1.CrossNamespaceObjectReference">
 CrossNamespaceObjectReference
 </a>
 </em>
@@ -797,7 +797,7 @@ ValuesFiles items. Ignored when omitted.</p>
 <td>
 <code>verify</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.HelmChartTemplateVerification">
+<a href="#cd.qdrant.io/v2beta1.HelmChartTemplateVerification">
 HelmChartTemplateVerification
 </a>
 </em>
@@ -815,11 +815,11 @@ Chart dependencies, which are not bundled in the umbrella chart artifact, are no
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2beta1.HelmChartTemplateVerification">HelmChartTemplateVerification
+<h3 id="cd.qdrant.io/v2beta1.HelmChartTemplateVerification">HelmChartTemplateVerification
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.HelmChartTemplateSpec">HelmChartTemplateSpec</a>)
+<a href="#cd.qdrant.io/v2beta1.HelmChartTemplateSpec">HelmChartTemplateSpec</a>)
 </p>
 <p>HelmChartTemplateVerification verifies the authenticity of an OCI Helm chart.</p>
 <div class="md-typeset__scrollwrap">
@@ -862,11 +862,11 @@ trusted public keys.</p>
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2beta1.HelmReleaseSpec">HelmReleaseSpec
+<h3 id="cd.qdrant.io/v2beta1.HelmReleaseSpec">HelmReleaseSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.HelmRelease">HelmRelease</a>)
+<a href="#cd.qdrant.io/v2beta1.HelmRelease">HelmRelease</a>)
 </p>
 <p>HelmReleaseSpec defines the desired state of a Helm release.</p>
 <div class="md-typeset__scrollwrap">
@@ -883,7 +883,7 @@ trusted public keys.</p>
 <td>
 <code>chart</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.HelmChartTemplate">
+<a href="#cd.qdrant.io/v2beta1.HelmChartTemplate">
 HelmChartTemplate
 </a>
 </em>
@@ -1061,7 +1061,7 @@ available by e.g. post-install hooks.</p>
 <td>
 <code>install</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.Install">
+<a href="#cd.qdrant.io/v2beta1.Install">
 Install
 </a>
 </em>
@@ -1075,7 +1075,7 @@ Install
 <td>
 <code>upgrade</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.Upgrade">
+<a href="#cd.qdrant.io/v2beta1.Upgrade">
 Upgrade
 </a>
 </em>
@@ -1089,7 +1089,7 @@ Upgrade
 <td>
 <code>test</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.Test">
+<a href="#cd.qdrant.io/v2beta1.Test">
 Test
 </a>
 </em>
@@ -1103,7 +1103,7 @@ Test
 <td>
 <code>rollback</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.Rollback">
+<a href="#cd.qdrant.io/v2beta1.Rollback">
 Rollback
 </a>
 </em>
@@ -1117,7 +1117,7 @@ Rollback
 <td>
 <code>uninstall</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.Uninstall">
+<a href="#cd.qdrant.io/v2beta1.Uninstall">
 Uninstall
 </a>
 </em>
@@ -1131,7 +1131,7 @@ Uninstall
 <td>
 <code>valuesFrom</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.ValuesReference">
+<a href="#cd.qdrant.io/v2beta1.ValuesReference">
 []ValuesReference
 </a>
 </em>
@@ -1159,7 +1159,7 @@ Kubernetes pkg/apis/apiextensions/v1.JSON
 <td>
 <code>postRenderers</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.PostRenderer">
+<a href="#cd.qdrant.io/v2beta1.PostRenderer">
 []PostRenderer
 </a>
 </em>
@@ -1174,11 +1174,11 @@ of their definition.</p>
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2beta1.HelmReleaseStatus">HelmReleaseStatus
+<h3 id="cd.qdrant.io/v2beta1.HelmReleaseStatus">HelmReleaseStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.HelmRelease">HelmRelease</a>)
+<a href="#cd.qdrant.io/v2beta1.HelmRelease">HelmRelease</a>)
 </p>
 <p>HelmReleaseStatus defines the observed state of a HelmRelease.</p>
 <div class="md-typeset__scrollwrap">
@@ -1337,11 +1337,11 @@ state. It is reset after a successful reconciliation.</p>
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2beta1.Install">Install
+<h3 id="cd.qdrant.io/v2beta1.Install">Install
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.HelmReleaseSpec">HelmReleaseSpec</a>)
+<a href="#cd.qdrant.io/v2beta1.HelmReleaseSpec">HelmReleaseSpec</a>)
 </p>
 <p>Install holds the configuration for Helm install actions performed for this
 HelmRelease.</p>
@@ -1375,7 +1375,7 @@ Jobs for hooks) during the performance of a Helm install action. Defaults to
 <td>
 <code>remediation</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.InstallRemediation">
+<a href="#cd.qdrant.io/v2beta1.InstallRemediation">
 InstallRemediation
 </a>
 </em>
@@ -1468,7 +1468,7 @@ CRDs are installed if not already present.</p>
 <td>
 <code>crds</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.CRDsPolicy">
+<a href="#cd.qdrant.io/v2beta1.CRDsPolicy">
 CRDsPolicy
 </a>
 </em>
@@ -1507,11 +1507,11 @@ On uninstall, the namespace will not be garbage collected.</p>
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2beta1.InstallRemediation">InstallRemediation
+<h3 id="cd.qdrant.io/v2beta1.InstallRemediation">InstallRemediation
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.Install">Install</a>)
+<a href="#cd.qdrant.io/v2beta1.Install">Install</a>)
 </p>
 <p>InstallRemediation holds the configuration for Helm install remediation.</p>
 <div class="md-typeset__scrollwrap">
@@ -1569,11 +1569,11 @@ no retries remain. Defaults to &lsquo;false&rsquo;.</p>
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2beta1.Kustomize">Kustomize
+<h3 id="cd.qdrant.io/v2beta1.Kustomize">Kustomize
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.PostRenderer">PostRenderer</a>)
+<a href="#cd.qdrant.io/v2beta1.PostRenderer">PostRenderer</a>)
 </p>
 <p>Kustomize Helm PostRenderer specification.</p>
 <div class="md-typeset__scrollwrap">
@@ -1649,11 +1649,11 @@ patch, but this operator is simpler to specify.</p>
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2beta1.PostRenderer">PostRenderer
+<h3 id="cd.qdrant.io/v2beta1.PostRenderer">PostRenderer
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.HelmReleaseSpec">HelmReleaseSpec</a>)
+<a href="#cd.qdrant.io/v2beta1.HelmReleaseSpec">HelmReleaseSpec</a>)
 </p>
 <p>PostRenderer contains a Helm PostRenderer specification.</p>
 <div class="md-typeset__scrollwrap">
@@ -1670,7 +1670,7 @@ patch, but this operator is simpler to specify.</p>
 <td>
 <code>kustomize</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.Kustomize">
+<a href="#cd.qdrant.io/v2beta1.Kustomize">
 Kustomize
 </a>
 </em>
@@ -1684,23 +1684,23 @@ Kustomize
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2beta1.Remediation">Remediation
+<h3 id="cd.qdrant.io/v2beta1.Remediation">Remediation
 </h3>
 <p>Remediation defines a consistent interface for InstallRemediation and
 UpgradeRemediation.</p>
-<h3 id="helm.toolkit.fluxcd.io/v2beta1.RemediationStrategy">RemediationStrategy
+<h3 id="cd.qdrant.io/v2beta1.RemediationStrategy">RemediationStrategy
 (<code>string</code> alias)</h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.UpgradeRemediation">UpgradeRemediation</a>)
+<a href="#cd.qdrant.io/v2beta1.UpgradeRemediation">UpgradeRemediation</a>)
 </p>
 <p>RemediationStrategy returns the strategy to use to remediate a failed install
 or upgrade.</p>
-<h3 id="helm.toolkit.fluxcd.io/v2beta1.Rollback">Rollback
+<h3 id="cd.qdrant.io/v2beta1.Rollback">Rollback
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.HelmReleaseSpec">HelmReleaseSpec</a>)
+<a href="#cd.qdrant.io/v2beta1.HelmReleaseSpec">HelmReleaseSpec</a>)
 </p>
 <p>Rollback holds the configuration for Helm rollback actions for this
 HelmRelease.</p>
@@ -1809,11 +1809,11 @@ rollback action when it fails.</p>
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2beta1.Test">Test
+<h3 id="cd.qdrant.io/v2beta1.Test">Test
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.HelmReleaseSpec">HelmReleaseSpec</a>)
+<a href="#cd.qdrant.io/v2beta1.HelmReleaseSpec">HelmReleaseSpec</a>)
 </p>
 <p>Test holds the configuration for Helm test actions for this HelmRelease.</p>
 <div class="md-typeset__scrollwrap">
@@ -1872,11 +1872,11 @@ actions in &lsquo;Install.IgnoreTestFailures&rsquo; and &lsquo;Upgrade.IgnoreTes
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2beta1.Uninstall">Uninstall
+<h3 id="cd.qdrant.io/v2beta1.Uninstall">Uninstall
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.HelmReleaseSpec">HelmReleaseSpec</a>)
+<a href="#cd.qdrant.io/v2beta1.HelmReleaseSpec">HelmReleaseSpec</a>)
 </p>
 <p>Uninstall holds the configuration for Helm uninstall actions for this
 HelmRelease.</p>
@@ -1961,11 +1961,11 @@ a Helm uninstall is performed.</p>
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2beta1.Upgrade">Upgrade
+<h3 id="cd.qdrant.io/v2beta1.Upgrade">Upgrade
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.HelmReleaseSpec">HelmReleaseSpec</a>)
+<a href="#cd.qdrant.io/v2beta1.HelmReleaseSpec">HelmReleaseSpec</a>)
 </p>
 <p>Upgrade holds the configuration for Helm upgrade actions for this
 HelmRelease.</p>
@@ -1999,7 +1999,7 @@ Jobs for hooks) during the performance of a Helm upgrade action. Defaults to
 <td>
 <code>remediation</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.UpgradeRemediation">
+<a href="#cd.qdrant.io/v2beta1.UpgradeRemediation">
 UpgradeRemediation
 </a>
 </em>
@@ -2104,7 +2104,7 @@ upgrade action when it fails.</p>
 <td>
 <code>crds</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.CRDsPolicy">
+<a href="#cd.qdrant.io/v2beta1.CRDsPolicy">
 CRDsPolicy
 </a>
 </em>
@@ -2128,11 +2128,11 @@ option users can opt-in to CRD upgrade, which is not (yet) natively supported by
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2beta1.UpgradeRemediation">UpgradeRemediation
+<h3 id="cd.qdrant.io/v2beta1.UpgradeRemediation">UpgradeRemediation
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.Upgrade">Upgrade</a>)
+<a href="#cd.qdrant.io/v2beta1.Upgrade">Upgrade</a>)
 </p>
 <p>UpgradeRemediation holds the configuration for Helm upgrade remediation.</p>
 <div class="md-typeset__scrollwrap">
@@ -2190,7 +2190,7 @@ no retries remain. Defaults to &lsquo;false&rsquo; unless &lsquo;Retries&rsquo; 
 <td>
 <code>strategy</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.RemediationStrategy">
+<a href="#cd.qdrant.io/v2beta1.RemediationStrategy">
 RemediationStrategy
 </a>
 </em>
@@ -2204,11 +2204,11 @@ RemediationStrategy
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2beta1.ValuesReference">ValuesReference
+<h3 id="cd.qdrant.io/v2beta1.ValuesReference">ValuesReference
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta1.HelmReleaseSpec">HelmReleaseSpec</a>)
+<a href="#cd.qdrant.io/v2beta1.HelmReleaseSpec">HelmReleaseSpec</a>)
 </p>
 <p>ValuesReference contains a reference to a resource containing Helm values,
 and optionally the key they can be found at.</p>

--- a/docs/api/v2beta2/helm.md
+++ b/docs/api/v2beta2/helm.md
@@ -2,16 +2,16 @@
 <p>Packages:</p>
 <ul class="simple">
 <li>
-<a href="#helm.toolkit.fluxcd.io%2fv2beta2">helm.toolkit.fluxcd.io/v2beta2</a>
+<a href="#cd.qdrant.io%2fv2beta2">cd.qdrant.io/v2beta2</a>
 </li>
 </ul>
-<h2 id="helm.toolkit.fluxcd.io/v2beta2">helm.toolkit.fluxcd.io/v2beta2</h2>
+<h2 id="cd.qdrant.io/v2beta2">cd.qdrant.io/v2beta2</h2>
 <p>Package v2beta2 contains API Schema definitions for the helm v2beta2 API group</p>
 Resource Types:
 <ul class="simple"><li>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.HelmRelease">HelmRelease</a>
+<a href="#cd.qdrant.io/v2beta2.HelmRelease">HelmRelease</a>
 </li></ul>
-<h3 id="helm.toolkit.fluxcd.io/v2beta2.HelmRelease">HelmRelease
+<h3 id="cd.qdrant.io/v2beta2.HelmRelease">HelmRelease
 </h3>
 <p>HelmRelease is the Schema for the helmreleases API</p>
 <div class="md-typeset__scrollwrap">
@@ -29,7 +29,7 @@ Resource Types:
 <code>apiVersion</code><br>
 string</td>
 <td>
-<code>helm.toolkit.fluxcd.io/v2beta2</code>
+<code>cd.qdrant.io/v2beta2</code>
 </td>
 </tr>
 <tr>
@@ -59,7 +59,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.HelmReleaseSpec">
+<a href="#cd.qdrant.io/v2beta2.HelmReleaseSpec">
 HelmReleaseSpec
 </a>
 </em>
@@ -72,7 +72,7 @@ HelmReleaseSpec
 <td>
 <code>chart</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.HelmChartTemplate">
+<a href="#cd.qdrant.io/v2beta2.HelmChartTemplate">
 HelmChartTemplate
 </a>
 </em>
@@ -87,7 +87,7 @@ for this HelmRelease.</p>
 <td>
 <code>chartRef</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.CrossNamespaceSourceReference">
+<a href="#cd.qdrant.io/v2beta2.CrossNamespaceSourceReference">
 CrossNamespaceSourceReference
 </a>
 </em>
@@ -264,7 +264,7 @@ available by e.g. post-install hooks.</p>
 <td>
 <code>driftDetection</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.DriftDetection">
+<a href="#cd.qdrant.io/v2beta2.DriftDetection">
 DriftDetection
 </a>
 </em>
@@ -280,7 +280,7 @@ currently existing in the cluster.</p>
 <td>
 <code>install</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.Install">
+<a href="#cd.qdrant.io/v2beta2.Install">
 Install
 </a>
 </em>
@@ -294,7 +294,7 @@ Install
 <td>
 <code>upgrade</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.Upgrade">
+<a href="#cd.qdrant.io/v2beta2.Upgrade">
 Upgrade
 </a>
 </em>
@@ -308,7 +308,7 @@ Upgrade
 <td>
 <code>test</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.Test">
+<a href="#cd.qdrant.io/v2beta2.Test">
 Test
 </a>
 </em>
@@ -322,7 +322,7 @@ Test
 <td>
 <code>rollback</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.Rollback">
+<a href="#cd.qdrant.io/v2beta2.Rollback">
 Rollback
 </a>
 </em>
@@ -336,7 +336,7 @@ Rollback
 <td>
 <code>uninstall</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.Uninstall">
+<a href="#cd.qdrant.io/v2beta2.Uninstall">
 Uninstall
 </a>
 </em>
@@ -350,7 +350,7 @@ Uninstall
 <td>
 <code>valuesFrom</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.ValuesReference">
+<a href="#cd.qdrant.io/v2beta2.ValuesReference">
 []ValuesReference
 </a>
 </em>
@@ -378,7 +378,7 @@ Kubernetes pkg/apis/apiextensions/v1.JSON
 <td>
 <code>postRenderers</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.PostRenderer">
+<a href="#cd.qdrant.io/v2beta2.PostRenderer">
 []PostRenderer
 </a>
 </em>
@@ -396,7 +396,7 @@ of their definition.</p>
 <td>
 <code>status</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.HelmReleaseStatus">
+<a href="#cd.qdrant.io/v2beta2.HelmReleaseStatus">
 HelmReleaseStatus
 </a>
 </em>
@@ -408,20 +408,20 @@ HelmReleaseStatus
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2beta2.CRDsPolicy">CRDsPolicy
+<h3 id="cd.qdrant.io/v2beta2.CRDsPolicy">CRDsPolicy
 (<code>string</code> alias)</h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.Install">Install</a>, 
-<a href="#helm.toolkit.fluxcd.io/v2beta2.Upgrade">Upgrade</a>)
+<a href="#cd.qdrant.io/v2beta2.Install">Install</a>, 
+<a href="#cd.qdrant.io/v2beta2.Upgrade">Upgrade</a>)
 </p>
 <p>CRDsPolicy defines the install/upgrade approach to use for CRDs when
 installing or upgrading a HelmRelease.</p>
-<h3 id="helm.toolkit.fluxcd.io/v2beta2.CrossNamespaceObjectReference">CrossNamespaceObjectReference
+<h3 id="cd.qdrant.io/v2beta2.CrossNamespaceObjectReference">CrossNamespaceObjectReference
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.HelmChartTemplateSpec">HelmChartTemplateSpec</a>)
+<a href="#cd.qdrant.io/v2beta2.HelmChartTemplateSpec">HelmChartTemplateSpec</a>)
 </p>
 <p>CrossNamespaceObjectReference contains enough information to let you locate
 the typed referenced object at cluster level.</p>
@@ -485,11 +485,11 @@ string
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2beta2.CrossNamespaceSourceReference">CrossNamespaceSourceReference
+<h3 id="cd.qdrant.io/v2beta2.CrossNamespaceSourceReference">CrossNamespaceSourceReference
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.HelmReleaseSpec">HelmReleaseSpec</a>)
+<a href="#cd.qdrant.io/v2beta2.HelmReleaseSpec">HelmReleaseSpec</a>)
 </p>
 <p>CrossNamespaceSourceReference contains enough information to let you locate
 the typed referenced object at cluster level.</p>
@@ -554,11 +554,11 @@ resource object that contains the reference.</p>
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2beta2.DriftDetection">DriftDetection
+<h3 id="cd.qdrant.io/v2beta2.DriftDetection">DriftDetection
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.HelmReleaseSpec">HelmReleaseSpec</a>)
+<a href="#cd.qdrant.io/v2beta2.HelmReleaseSpec">HelmReleaseSpec</a>)
 </p>
 <p>DriftDetection defines the strategy for performing differential analysis and
 provides a way to define rules for ignoring specific changes during this
@@ -577,7 +577,7 @@ process.</p>
 <td>
 <code>mode</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.DriftDetectionMode">
+<a href="#cd.qdrant.io/v2beta2.DriftDetectionMode">
 DriftDetectionMode
 </a>
 </em>
@@ -593,7 +593,7 @@ If not explicitly set, it defaults to DiffModeDisabled.</p>
 <td>
 <code>ignore</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.IgnoreRule">
+<a href="#cd.qdrant.io/v2beta2.IgnoreRule">
 []IgnoreRule
 </a>
 </em>
@@ -608,20 +608,20 @@ during diffing.</p>
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2beta2.DriftDetectionMode">DriftDetectionMode
+<h3 id="cd.qdrant.io/v2beta2.DriftDetectionMode">DriftDetectionMode
 (<code>string</code> alias)</h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.DriftDetection">DriftDetection</a>)
+<a href="#cd.qdrant.io/v2beta2.DriftDetection">DriftDetection</a>)
 </p>
 <p>DriftDetectionMode represents the modes in which a controller can detect and
 handle differences between the manifest in the Helm storage and the resources
 currently existing in the cluster.</p>
-<h3 id="helm.toolkit.fluxcd.io/v2beta2.Filter">Filter
+<h3 id="cd.qdrant.io/v2beta2.Filter">Filter
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.Test">Test</a>)
+<a href="#cd.qdrant.io/v2beta2.Test">Test</a>)
 </p>
 <p>Filter holds the configuration for individual Helm test filters.</p>
 <div class="md-typeset__scrollwrap">
@@ -661,11 +661,11 @@ bool
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2beta2.HelmChartTemplate">HelmChartTemplate
+<h3 id="cd.qdrant.io/v2beta2.HelmChartTemplate">HelmChartTemplate
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.HelmReleaseSpec">HelmReleaseSpec</a>)
+<a href="#cd.qdrant.io/v2beta2.HelmReleaseSpec">HelmReleaseSpec</a>)
 </p>
 <p>HelmChartTemplate defines the template from which the controller will
 generate a v1beta2.HelmChart object in the same namespace as the referenced
@@ -684,7 +684,7 @@ v1.Source.</p>
 <td>
 <code>metadata</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.HelmChartTemplateObjectMeta">
+<a href="#cd.qdrant.io/v2beta2.HelmChartTemplateObjectMeta">
 HelmChartTemplateObjectMeta
 </a>
 </em>
@@ -698,7 +698,7 @@ HelmChartTemplateObjectMeta
 <td>
 <code>spec</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.HelmChartTemplateSpec">
+<a href="#cd.qdrant.io/v2beta2.HelmChartTemplateSpec">
 HelmChartTemplateSpec
 </a>
 </em>
@@ -736,7 +736,7 @@ v1beta2.Bucket sources. Defaults to latest when omitted.</p>
 <td>
 <code>sourceRef</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.CrossNamespaceObjectReference">
+<a href="#cd.qdrant.io/v2beta2.CrossNamespaceObjectReference">
 CrossNamespaceObjectReference
 </a>
 </em>
@@ -821,7 +821,7 @@ bool
 <td>
 <code>verify</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.HelmChartTemplateVerification">
+<a href="#cd.qdrant.io/v2beta2.HelmChartTemplateVerification">
 HelmChartTemplateVerification
 </a>
 </em>
@@ -843,11 +843,11 @@ are not verified.</p>
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2beta2.HelmChartTemplateObjectMeta">HelmChartTemplateObjectMeta
+<h3 id="cd.qdrant.io/v2beta2.HelmChartTemplateObjectMeta">HelmChartTemplateObjectMeta
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.HelmChartTemplate">HelmChartTemplate</a>)
+<a href="#cd.qdrant.io/v2beta2.HelmChartTemplate">HelmChartTemplate</a>)
 </p>
 <p>HelmChartTemplateObjectMeta defines the template for the ObjectMeta of a
 v1beta2.HelmChart.</p>
@@ -894,11 +894,11 @@ More info: <a href="https://kubernetes.io/docs/concepts/overview/working-with-ob
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2beta2.HelmChartTemplateSpec">HelmChartTemplateSpec
+<h3 id="cd.qdrant.io/v2beta2.HelmChartTemplateSpec">HelmChartTemplateSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.HelmChartTemplate">HelmChartTemplate</a>)
+<a href="#cd.qdrant.io/v2beta2.HelmChartTemplate">HelmChartTemplate</a>)
 </p>
 <p>HelmChartTemplateSpec defines the template from which the controller will
 generate a v1beta2.HelmChartSpec object.</p>
@@ -940,7 +940,7 @@ v1beta2.Bucket sources. Defaults to latest when omitted.</p>
 <td>
 <code>sourceRef</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.CrossNamespaceObjectReference">
+<a href="#cd.qdrant.io/v2beta2.CrossNamespaceObjectReference">
 CrossNamespaceObjectReference
 </a>
 </em>
@@ -1025,7 +1025,7 @@ bool
 <td>
 <code>verify</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.HelmChartTemplateVerification">
+<a href="#cd.qdrant.io/v2beta2.HelmChartTemplateVerification">
 HelmChartTemplateVerification
 </a>
 </em>
@@ -1044,11 +1044,11 @@ are not verified.</p>
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2beta2.HelmChartTemplateVerification">HelmChartTemplateVerification
+<h3 id="cd.qdrant.io/v2beta2.HelmChartTemplateVerification">HelmChartTemplateVerification
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.HelmChartTemplateSpec">HelmChartTemplateSpec</a>)
+<a href="#cd.qdrant.io/v2beta2.HelmChartTemplateSpec">HelmChartTemplateSpec</a>)
 </p>
 <p>HelmChartTemplateVerification verifies the authenticity of an OCI Helm chart.</p>
 <div class="md-typeset__scrollwrap">
@@ -1091,11 +1091,11 @@ trusted public keys.</p>
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2beta2.HelmReleaseSpec">HelmReleaseSpec
+<h3 id="cd.qdrant.io/v2beta2.HelmReleaseSpec">HelmReleaseSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.HelmRelease">HelmRelease</a>)
+<a href="#cd.qdrant.io/v2beta2.HelmRelease">HelmRelease</a>)
 </p>
 <p>HelmReleaseSpec defines the desired state of a Helm release.</p>
 <div class="md-typeset__scrollwrap">
@@ -1112,7 +1112,7 @@ trusted public keys.</p>
 <td>
 <code>chart</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.HelmChartTemplate">
+<a href="#cd.qdrant.io/v2beta2.HelmChartTemplate">
 HelmChartTemplate
 </a>
 </em>
@@ -1127,7 +1127,7 @@ for this HelmRelease.</p>
 <td>
 <code>chartRef</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.CrossNamespaceSourceReference">
+<a href="#cd.qdrant.io/v2beta2.CrossNamespaceSourceReference">
 CrossNamespaceSourceReference
 </a>
 </em>
@@ -1304,7 +1304,7 @@ available by e.g. post-install hooks.</p>
 <td>
 <code>driftDetection</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.DriftDetection">
+<a href="#cd.qdrant.io/v2beta2.DriftDetection">
 DriftDetection
 </a>
 </em>
@@ -1320,7 +1320,7 @@ currently existing in the cluster.</p>
 <td>
 <code>install</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.Install">
+<a href="#cd.qdrant.io/v2beta2.Install">
 Install
 </a>
 </em>
@@ -1334,7 +1334,7 @@ Install
 <td>
 <code>upgrade</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.Upgrade">
+<a href="#cd.qdrant.io/v2beta2.Upgrade">
 Upgrade
 </a>
 </em>
@@ -1348,7 +1348,7 @@ Upgrade
 <td>
 <code>test</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.Test">
+<a href="#cd.qdrant.io/v2beta2.Test">
 Test
 </a>
 </em>
@@ -1362,7 +1362,7 @@ Test
 <td>
 <code>rollback</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.Rollback">
+<a href="#cd.qdrant.io/v2beta2.Rollback">
 Rollback
 </a>
 </em>
@@ -1376,7 +1376,7 @@ Rollback
 <td>
 <code>uninstall</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.Uninstall">
+<a href="#cd.qdrant.io/v2beta2.Uninstall">
 Uninstall
 </a>
 </em>
@@ -1390,7 +1390,7 @@ Uninstall
 <td>
 <code>valuesFrom</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.ValuesReference">
+<a href="#cd.qdrant.io/v2beta2.ValuesReference">
 []ValuesReference
 </a>
 </em>
@@ -1418,7 +1418,7 @@ Kubernetes pkg/apis/apiextensions/v1.JSON
 <td>
 <code>postRenderers</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.PostRenderer">
+<a href="#cd.qdrant.io/v2beta2.PostRenderer">
 []PostRenderer
 </a>
 </em>
@@ -1433,11 +1433,11 @@ of their definition.</p>
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2beta2.HelmReleaseStatus">HelmReleaseStatus
+<h3 id="cd.qdrant.io/v2beta2.HelmReleaseStatus">HelmReleaseStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.HelmRelease">HelmRelease</a>)
+<a href="#cd.qdrant.io/v2beta2.HelmRelease">HelmRelease</a>)
 </p>
 <p>HelmReleaseStatus defines the observed state of a HelmRelease.</p>
 <div class="md-typeset__scrollwrap">
@@ -1519,7 +1519,7 @@ current release.</p>
 <td>
 <code>history</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.Snapshots">
+<a href="#cd.qdrant.io/v2beta2.Snapshots">
 Snapshots
 </a>
 </em>
@@ -1534,7 +1534,7 @@ up to the last successfully completed release.</p>
 <td>
 <code>lastAttemptedReleaseAction</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.ReleaseAction">
+<a href="#cd.qdrant.io/v2beta2.ReleaseAction">
 ReleaseAction
 </a>
 </em>
@@ -1710,11 +1710,11 @@ github.com/fluxcd/pkg/apis/meta.ReconcileRequestStatus
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2beta2.IgnoreRule">IgnoreRule
+<h3 id="cd.qdrant.io/v2beta2.IgnoreRule">IgnoreRule
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.DriftDetection">DriftDetection</a>)
+<a href="#cd.qdrant.io/v2beta2.DriftDetection">DriftDetection</a>)
 </p>
 <p>IgnoreRule defines a rule to selectively disregard specific changes during
 the drift detection process.</p>
@@ -1761,11 +1761,11 @@ objects within the manifest of the Helm release.</p>
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2beta2.Install">Install
+<h3 id="cd.qdrant.io/v2beta2.Install">Install
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.HelmReleaseSpec">HelmReleaseSpec</a>)
+<a href="#cd.qdrant.io/v2beta2.HelmReleaseSpec">HelmReleaseSpec</a>)
 </p>
 <p>Install holds the configuration for Helm install actions performed for this
 HelmRelease.</p>
@@ -1799,7 +1799,7 @@ Jobs for hooks) during the performance of a Helm install action. Defaults to
 <td>
 <code>remediation</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.InstallRemediation">
+<a href="#cd.qdrant.io/v2beta2.InstallRemediation">
 InstallRemediation
 </a>
 </em>
@@ -1892,7 +1892,7 @@ CRDs are installed if not already present.</p>
 <td>
 <code>crds</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.CRDsPolicy">
+<a href="#cd.qdrant.io/v2beta2.CRDsPolicy">
 CRDsPolicy
 </a>
 </em>
@@ -1931,11 +1931,11 @@ On uninstall, the namespace will not be garbage collected.</p>
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2beta2.InstallRemediation">InstallRemediation
+<h3 id="cd.qdrant.io/v2beta2.InstallRemediation">InstallRemediation
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.Install">Install</a>)
+<a href="#cd.qdrant.io/v2beta2.Install">Install</a>)
 </p>
 <p>InstallRemediation holds the configuration for Helm install remediation.</p>
 <div class="md-typeset__scrollwrap">
@@ -1993,11 +1993,11 @@ no retries remain. Defaults to &lsquo;false&rsquo;.</p>
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2beta2.Kustomize">Kustomize
+<h3 id="cd.qdrant.io/v2beta2.Kustomize">Kustomize
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.PostRenderer">PostRenderer</a>)
+<a href="#cd.qdrant.io/v2beta2.PostRenderer">PostRenderer</a>)
 </p>
 <p>Kustomize Helm PostRenderer specification.</p>
 <div class="md-typeset__scrollwrap">
@@ -2075,11 +2075,11 @@ patch, but this operator is simpler to specify.</p>
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2beta2.PostRenderer">PostRenderer
+<h3 id="cd.qdrant.io/v2beta2.PostRenderer">PostRenderer
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.HelmReleaseSpec">HelmReleaseSpec</a>)
+<a href="#cd.qdrant.io/v2beta2.HelmReleaseSpec">HelmReleaseSpec</a>)
 </p>
 <p>PostRenderer contains a Helm PostRenderer specification.</p>
 <div class="md-typeset__scrollwrap">
@@ -2096,7 +2096,7 @@ patch, but this operator is simpler to specify.</p>
 <td>
 <code>kustomize</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.Kustomize">
+<a href="#cd.qdrant.io/v2beta2.Kustomize">
 Kustomize
 </a>
 </em>
@@ -2110,30 +2110,30 @@ Kustomize
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2beta2.ReleaseAction">ReleaseAction
+<h3 id="cd.qdrant.io/v2beta2.ReleaseAction">ReleaseAction
 (<code>string</code> alias)</h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.HelmReleaseStatus">HelmReleaseStatus</a>)
+<a href="#cd.qdrant.io/v2beta2.HelmReleaseStatus">HelmReleaseStatus</a>)
 </p>
 <p>ReleaseAction is the action to perform a Helm release.</p>
-<h3 id="helm.toolkit.fluxcd.io/v2beta2.Remediation">Remediation
+<h3 id="cd.qdrant.io/v2beta2.Remediation">Remediation
 </h3>
 <p>Remediation defines a consistent interface for InstallRemediation and
 UpgradeRemediation.</p>
-<h3 id="helm.toolkit.fluxcd.io/v2beta2.RemediationStrategy">RemediationStrategy
+<h3 id="cd.qdrant.io/v2beta2.RemediationStrategy">RemediationStrategy
 (<code>string</code> alias)</h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.UpgradeRemediation">UpgradeRemediation</a>)
+<a href="#cd.qdrant.io/v2beta2.UpgradeRemediation">UpgradeRemediation</a>)
 </p>
 <p>RemediationStrategy returns the strategy to use to remediate a failed install
 or upgrade.</p>
-<h3 id="helm.toolkit.fluxcd.io/v2beta2.Rollback">Rollback
+<h3 id="cd.qdrant.io/v2beta2.Rollback">Rollback
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.HelmReleaseSpec">HelmReleaseSpec</a>)
+<a href="#cd.qdrant.io/v2beta2.HelmReleaseSpec">HelmReleaseSpec</a>)
 </p>
 <p>Rollback holds the configuration for Helm rollback actions for this
 HelmRelease.</p>
@@ -2242,7 +2242,7 @@ rollback action when it fails.</p>
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2beta2.Snapshot">Snapshot
+<h3 id="cd.qdrant.io/v2beta2.Snapshot">Snapshot
 </h3>
 <p>Snapshot captures a point-in-time copy of the status information for a Helm release,
 as managed by the controller.</p>
@@ -2406,7 +2406,7 @@ Kubernetes meta/v1.Time
 <td>
 <code>testHooks</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.TestHookStatus">
+<a href="#cd.qdrant.io/v2beta2.TestHookStatus">
 TestHookStatus
 </a>
 </em>
@@ -2433,18 +2433,18 @@ string
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2beta2.Snapshots">Snapshots
+<h3 id="cd.qdrant.io/v2beta2.Snapshots">Snapshots
 (<code>[]*./api/v2beta2.Snapshot</code> alias)</h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.HelmReleaseStatus">HelmReleaseStatus</a>)
+<a href="#cd.qdrant.io/v2beta2.HelmReleaseStatus">HelmReleaseStatus</a>)
 </p>
 <p>Snapshots is a list of Snapshot objects.</p>
-<h3 id="helm.toolkit.fluxcd.io/v2beta2.Test">Test
+<h3 id="cd.qdrant.io/v2beta2.Test">Test
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.HelmReleaseSpec">HelmReleaseSpec</a>)
+<a href="#cd.qdrant.io/v2beta2.HelmReleaseSpec">HelmReleaseSpec</a>)
 </p>
 <p>Test holds the configuration for Helm test actions for this HelmRelease.</p>
 <div class="md-typeset__scrollwrap">
@@ -2503,7 +2503,7 @@ actions in &lsquo;Install.IgnoreTestFailures&rsquo; and &lsquo;Upgrade.IgnoreTes
 <td>
 <code>filters</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.Filter">
+<a href="#cd.qdrant.io/v2beta2.Filter">
 Filter
 </a>
 </em>
@@ -2516,11 +2516,11 @@ Filter
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2beta2.TestHookStatus">TestHookStatus
+<h3 id="cd.qdrant.io/v2beta2.TestHookStatus">TestHookStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.Snapshot">Snapshot</a>)
+<a href="#cd.qdrant.io/v2beta2.Snapshot">Snapshot</a>)
 </p>
 <p>TestHookStatus holds the status information for a test hook as observed
 to be run by the controller.</p>
@@ -2578,11 +2578,11 @@ string
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2beta2.Uninstall">Uninstall
+<h3 id="cd.qdrant.io/v2beta2.Uninstall">Uninstall
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.HelmReleaseSpec">HelmReleaseSpec</a>)
+<a href="#cd.qdrant.io/v2beta2.HelmReleaseSpec">HelmReleaseSpec</a>)
 </p>
 <p>Uninstall holds the configuration for Helm uninstall actions for this
 HelmRelease.</p>
@@ -2667,11 +2667,11 @@ a Helm uninstall is performed.</p>
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2beta2.Upgrade">Upgrade
+<h3 id="cd.qdrant.io/v2beta2.Upgrade">Upgrade
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.HelmReleaseSpec">HelmReleaseSpec</a>)
+<a href="#cd.qdrant.io/v2beta2.HelmReleaseSpec">HelmReleaseSpec</a>)
 </p>
 <p>Upgrade holds the configuration for Helm upgrade actions for this
 HelmRelease.</p>
@@ -2705,7 +2705,7 @@ Jobs for hooks) during the performance of a Helm upgrade action. Defaults to
 <td>
 <code>remediation</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.UpgradeRemediation">
+<a href="#cd.qdrant.io/v2beta2.UpgradeRemediation">
 UpgradeRemediation
 </a>
 </em>
@@ -2810,7 +2810,7 @@ upgrade action when it fails.</p>
 <td>
 <code>crds</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.CRDsPolicy">
+<a href="#cd.qdrant.io/v2beta2.CRDsPolicy">
 CRDsPolicy
 </a>
 </em>
@@ -2834,11 +2834,11 @@ option users can opt-in to CRD upgrade, which is not (yet) natively supported by
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2beta2.UpgradeRemediation">UpgradeRemediation
+<h3 id="cd.qdrant.io/v2beta2.UpgradeRemediation">UpgradeRemediation
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.Upgrade">Upgrade</a>)
+<a href="#cd.qdrant.io/v2beta2.Upgrade">Upgrade</a>)
 </p>
 <p>UpgradeRemediation holds the configuration for Helm upgrade remediation.</p>
 <div class="md-typeset__scrollwrap">
@@ -2896,7 +2896,7 @@ no retries remain. Defaults to &lsquo;false&rsquo; unless &lsquo;Retries&rsquo; 
 <td>
 <code>strategy</code><br>
 <em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.RemediationStrategy">
+<a href="#cd.qdrant.io/v2beta2.RemediationStrategy">
 RemediationStrategy
 </a>
 </em>
@@ -2910,11 +2910,11 @@ RemediationStrategy
 </table>
 </div>
 </div>
-<h3 id="helm.toolkit.fluxcd.io/v2beta2.ValuesReference">ValuesReference
+<h3 id="cd.qdrant.io/v2beta2.ValuesReference">ValuesReference
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2beta2.HelmReleaseSpec">HelmReleaseSpec</a>)
+<a href="#cd.qdrant.io/v2beta2.HelmReleaseSpec">HelmReleaseSpec</a>)
 </p>
 <p>ValuesReference contains a reference to a resource containing Helm values,
 and optionally the key they can be found at.</p>

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -51,7 +51,7 @@ trigger a Helm uninstall.
 Alerting can be configured with a Kubernetes custom resource that specifies a webhook address, and a
 group of `HelmRelease` resources to be monitored using the [notification-controller](https://github.com/fluxcd/notification-controller).
 
-The API design of the controller can be found at [helm.toolkit.fluxcd.io/v2](./v2/helmreleases.md).
+The API design of the controller can be found at [cd.qdrant.io/v2](./v2/helmreleases.md).
 
 ## Backward compatibility
 

--- a/docs/spec/v2/README.md
+++ b/docs/spec/v2/README.md
@@ -1,4 +1,4 @@
-# helm.toolkit.fluxcd.io/v2
+# cd.qdrant.io/v2
 
 This is the v2 API specification for declaratively managing Helm chart
 releases with Kubernetes manifests.

--- a/docs/spec/v2/helmreleases.md
+++ b/docs/spec/v2/helmreleases.md
@@ -14,7 +14,7 @@ The following is an example of a HelmRelease which installs the
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: HelmRepository
 metadata:
   name: podinfo
@@ -23,7 +23,7 @@ spec:
   interval: 5m
   url: https://stefanprodan.github.io/podinfo
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2
+apiVersion: cd.qdrant.io/v2
 kind: HelmRelease
 metadata:
   name: podinfo
@@ -229,7 +229,7 @@ HelmRelease object.
 #### OCIRepository reference example
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: OCIRepository
 metadata:
   name: podinfo
@@ -243,7 +243,7 @@ spec:
   ref:
     semver: ">= 6.0.0"
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2
+apiVersion: cd.qdrant.io/v2
 kind: HelmRelease
 metadata:
   name: podinfo
@@ -261,7 +261,7 @@ spec:
 #### HelmChart reference example
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: HelmChart
 metadata:
   name: podinfo
@@ -276,7 +276,7 @@ spec:
   valuesFiles:
     - values-prod.yaml
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2
+apiVersion: cd.qdrant.io/v2
 kind: HelmRelease
 metadata:
   name: podinfo
@@ -374,7 +374,7 @@ Defintions and the related controller must exist in the cluster.
 
 ```yaml
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2
+apiVersion: cd.qdrant.io/v2
 kind: HelmRelease
 metadata:
   name: backend
@@ -382,7 +382,7 @@ metadata:
 spec:
   # ...omitted for brevity   
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2
+apiVersion: cd.qdrant.io/v2
 kind: HelmRelease
 metadata:
   name: frontend
@@ -721,7 +721,7 @@ causes the selector to be more specific:
 
 - `group` (Optional): Matches the `.apiVersion` group of resources while
   offering support for regular expressions. For example, `apps`,
-  `helm.toolkit.fluxcd.io` or `.*.toolkit.fluxcd.io`.
+  `cd.qdrant.io` or `.*.toolkit.fluxcd.io`.
 - `version` (Optional): Matches the `.apiVersion` version of resources while
   offering support for regular expressions. For example, `v1`, `v2beta2` or
   `v2beta[\d]`.
@@ -743,7 +743,7 @@ causes the selector to be more specific:
 #### Ignore annotation
 
 To exclude certain resources from the comparison, they can be labeled or
-annotated with `helm.toolkit.fluxcd.io/driftDetection: disabled`. Using
+annotated with `cd.qdrant.io/driftDetection: disabled`. Using
 [post-renderers](#post-renderers), this can be applied to any resource
 rendered by Helm.
 
@@ -758,7 +758,7 @@ spec:
               name: my-app
             patch: |
               - op: add
-                path: /metadata/annotations/helm.toolkit.fluxcd.io~1driftDetection
+                path: /metadata/annotations/cd.qdrant.io~1driftDetection
                 value: disabled
 ```
 
@@ -949,7 +949,7 @@ chart, you can set the `.spec.install.crds` and `.spec.upgrade.crds` policies to
 
 ```yaml
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2
+apiVersion: cd.qdrant.io/v2
 kind: HelmRelease
 metadata:
   name: my-operator
@@ -1036,7 +1036,7 @@ The Service Account can then be referenced in the HelmRelease:
 
 ```yaml
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2
+apiVersion: cd.qdrant.io/v2
 kind: HelmRelease
 metadata:
  name: podinfo
@@ -1110,7 +1110,7 @@ spec:
 ---
 # ... unrelated Cluster API objects omitted for brevity ...
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2
+apiVersion: cd.qdrant.io/v2
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack
@@ -1244,7 +1244,7 @@ In your YAML declaration:
 
 ```yaml
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2
+apiVersion: cd.qdrant.io/v2
 kind: HelmRelease
 metadata:
   name: <helmrelease-name>
@@ -1270,7 +1270,7 @@ In your YAML declaration, comment out (or remove) the field:
 
 ```yaml
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2
+apiVersion: cd.qdrant.io/v2
 kind: HelmRelease
 metadata:
   name: <helmrelease-name>
@@ -1411,15 +1411,15 @@ apiVersion: v1
 kind: Event
 metadata:
   annotations:
-    helm.toolkit.fluxcd.io/app-version: 6.6.1
-    helm.toolkit.fluxcd.io/revision: 6.6.1+0cc9a8446c95
-    helm.toolkit.fluxcd.io/oci-digest: sha256:0cc9a8446c95009ef382f5eade883a67c257f77d50f84e78ecef2aac9428d1e5
+    cd.qdrant.io/app-version: 6.6.1
+    cd.qdrant.io/revision: 6.6.1+0cc9a8446c95
+    cd.qdrant.io/oci-digest: sha256:0cc9a8446c95009ef382f5eade883a67c257f77d50f84e78ecef2aac9428d1e5
   creationTimestamp: "2024-05-07T05:02:34Z"
   name: podinfo.17cd1c4e15d474bb
   namespace: default
 firstTimestamp: "2024-05-07T05:02:34Z"
 involvedObject:
-  apiVersion: helm.toolkit.fluxcd.io/v2
+  apiVersion: cd.qdrant.io/v2
   kind: HelmRelease
   name: podinfo
   namespace: default
@@ -1446,7 +1446,7 @@ include the status of the tests which were run for each release.
 
 ```yaml
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2
+apiVersion: cd.qdrant.io/v2
 kind: HelmRelease
 metadata:
   name: <release-name>

--- a/docs/spec/v2alpha1/README.md
+++ b/docs/spec/v2alpha1/README.md
@@ -1,4 +1,4 @@
-# helm.toolkit.fluxcd.io/v2alpha1
+# cd.qdrant.io/v2alpha1
 
 This is the v2alpha1 API specification for declaratively managing Helm chart releases with
 Kubernetes manifests.

--- a/docs/spec/v2alpha1/helmreleases.md
+++ b/docs/spec/v2alpha1/helmreleases.md
@@ -638,8 +638,8 @@ To list all Kubernetes objects reconciled from a HelmRelease:
 
 ```sh
 kubectl get all --all-namespaces \
-  -l=helm.toolkit.fluxcd.io/name="<HelmRelease name>" \
-  -l=helm.toolkit.fluxcd.io/namespace="<HelmRelease namespace>"
+  -l=cd.qdrant.io/name="<HelmRelease name>" \
+  -l=cd.qdrant.io/namespace="<HelmRelease namespace>"
 ```
 
 ### Disabling resource waiting
@@ -660,7 +660,7 @@ Assuming two `HelmRelease` resources:
 - `frontend` - contains the frontend of the application and relies on the backend
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2alpha1
+apiVersion: cd.qdrant.io/v2alpha1
 kind: HelmRelease
 metadata:
   name: backend
@@ -687,7 +687,7 @@ spec:
         cpu: 100m
         memory: 64Mi
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2alpha1
+apiVersion: cd.qdrant.io/v2alpha1
 kind: HelmRelease
 metadata:
   name: frontend
@@ -735,7 +735,7 @@ can be overridden per Helm action by setting `spec.install.remediation.ignoreTes
 or `spec.upgrade.remediation.ignoreTestFailures`.
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2alpha1
+apiVersion: cd.qdrant.io/v2alpha1
 kind: HelmRelease
 metadata:
   name: podinfo

--- a/docs/spec/v2beta1/README.md
+++ b/docs/spec/v2beta1/README.md
@@ -1,4 +1,4 @@
-# helm.toolkit.fluxcd.io/v2beta1
+# cd.qdrant.io/v2beta1
 
 This is the v2beta1 API specification for declaratively managing Helm chart releases with
 Kubernetes manifests.

--- a/docs/spec/v2beta1/helmreleases.md
+++ b/docs/spec/v2beta1/helmreleases.md
@@ -846,8 +846,8 @@ List all Kubernetes objects reconciled from a HelmRelease:
 
 ```sh
 kubectl get all --all-namespaces \
--l=helm.toolkit.fluxcd.io/name="<HelmRelease name>" \
--l=helm.toolkit.fluxcd.io/namespace="<HelmRelease namespace>"
+-l=cd.qdrant.io/name="<HelmRelease name>" \
+-l=cd.qdrant.io/namespace="<HelmRelease namespace>"
 ```
 
 ### Disabling resource waiting
@@ -871,7 +871,7 @@ Assuming two `HelmRelease` resources:
 - `frontend` - contains the frontend of the application and relies on the backend
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: cd.qdrant.io/v2beta1
 kind: HelmRelease
 metadata:
   name: backend
@@ -900,7 +900,7 @@ spec:
         cpu: 100m
         memory: 64Mi
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: cd.qdrant.io/v2beta1
 kind: HelmRelease
 metadata:
   name: frontend
@@ -950,7 +950,7 @@ can be overridden per Helm action by setting `spec.install.remediation.ignoreTes
 or `spec.upgrade.remediation.ignoreTestFailures`.
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: cd.qdrant.io/v2beta1
 kind: HelmRelease
 metadata:
   name: podinfo
@@ -995,7 +995,7 @@ One can also opt-in to remediation of the last failure (when no retries remain) 
 to true if at least one retry is configured.
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: cd.qdrant.io/v2beta1
 kind: HelmRelease
 metadata:
   name: podinfo
@@ -1078,7 +1078,7 @@ subjects:
 Create a `HelmRelease` that prevents altering the cluster state outside of the `webapp` namespace:
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: cd.qdrant.io/v2beta1
 kind: HelmRelease
 metadata:
   name: podinfo
@@ -1162,7 +1162,7 @@ spec:
 ---
 # ... unrelated Cluster API objects omitted for brevity ...
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: cd.qdrant.io/v2beta1
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack
@@ -1220,7 +1220,7 @@ which adds a [toleration](https://kubernetes.io/docs/concepts/scheduling-evictio
 to the Helm rendered output:
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: cd.qdrant.io/v2beta1
 kind: HelmRelease
 metadata:
   name: metrics-server
@@ -1303,7 +1303,7 @@ The following CRD upgrade policies are supported:
 **Example**:
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: cd.qdrant.io/v2beta1
 kind: HelmRelease
 metadata:
   name: my-operator
@@ -1345,11 +1345,11 @@ feature full.
 ### Excluding resources from drift detection
 
 The drift detection feature can be configured to exclude certain resources from the comparison
-by labeling or annotating them with `helm.toolkit.fluxcd.io/driftDetection: disabled`. Using
+by labeling or annotating them with `cd.qdrant.io/driftDetection: disabled`. Using
 [post-renderers](#post-renderers), this can be applied to any resource rendered by Helm.
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: cd.qdrant.io/v2beta1
 kind: HelmRelease
 metadata:
   name: app
@@ -1364,7 +1364,7 @@ spec:
               name: my-app
             patch: |
               - op: add
-                path: /metadata/annotations/helm.toolkit.fluxcd.io~1driftDetection
+                path: /metadata/annotations/cd.qdrant.io~1driftDetection
                 value: disabled
 ```
 
@@ -1378,7 +1378,7 @@ more fitting solution than ignoring the object in full.
 
 ```yaml
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: cd.qdrant.io/v2beta1
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack
@@ -1406,7 +1406,7 @@ spec:
               name: kube-prometheus-stack-admission
             patch: |
               - op: add
-                path: /metadata/annotations/helm.toolkit.fluxcd.io~1driftDetection
+                path: /metadata/annotations/cd.qdrant.io~1driftDetection
                 value: disabled
           - target:
               # Ignore these objects from Flux diff as they are mutated at apply time but not
@@ -1414,7 +1414,7 @@ spec:
               kind: PrometheusRule
             patch: |
               - op: add
-                path: /metadata/annotations/helm.toolkit.fluxcd.io~1driftDetection
+                path: /metadata/annotations/cd.qdrant.io~1driftDetection
                 value: disabled
 ```
 

--- a/docs/spec/v2beta2/README.md
+++ b/docs/spec/v2beta2/README.md
@@ -1,4 +1,4 @@
-# helm.toolkit.fluxcd.io/v2beta2
+# cd.qdrant.io/v2beta2
 
 This is the v2beta2 API specification for declaratively managing Helm chart
 releases with Kubernetes manifests.

--- a/docs/spec/v2beta2/helmreleases.md
+++ b/docs/spec/v2beta2/helmreleases.md
@@ -14,7 +14,7 @@ The following is an example of a HelmRelease which installs the
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: HelmRepository
 metadata:
   name: podinfo
@@ -23,7 +23,7 @@ spec:
   interval: 5m
   url: https://stefanprodan.github.io/podinfo
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: podinfo
@@ -229,7 +229,7 @@ HelmRelease object.
 #### OCIRepository reference example
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: OCIRepository
 metadata:
   name: podinfo
@@ -240,7 +240,7 @@ spec:
   ref:
     tag: 6.6.0
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: podinfo
@@ -258,7 +258,7 @@ spec:
 #### HelmChart reference example
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: HelmChart
 metadata:
   name: podinfo
@@ -272,7 +272,7 @@ spec:
     name: podinfo
   version: '5.*'
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: podinfo
@@ -370,7 +370,7 @@ Defintions and the related controller must exist in the cluster.
 
 ```yaml
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: backend
@@ -378,7 +378,7 @@ metadata:
 spec:
   # ...omitted for brevity   
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: frontend
@@ -717,7 +717,7 @@ causes the selector to be more specific:
 
 - `group` (Optional): Matches the `.apiVersion` group of resources while
   offering support for regular expressions. For example, `apps`,
-  `helm.toolkit.fluxcd.io` or `.*.toolkit.fluxcd.io`.
+  `cd.qdrant.io` or `.*.toolkit.fluxcd.io`.
 - `version` (Optional): Matches the `.apiVersion` version of resources while
   offering support for regular expressions. For example, `v1`, `v2beta2` or
   `v2beta[\d]`.
@@ -739,7 +739,7 @@ causes the selector to be more specific:
 #### Ignore annotation
 
 To exclude certain resources from the comparison, they can be labeled or
-annotated with `helm.toolkit.fluxcd.io/driftDetection: disabled`. Using
+annotated with `cd.qdrant.io/driftDetection: disabled`. Using
 [post-renderers](#post-renderers), this can be applied to any resource
 rendered by Helm.
 
@@ -754,7 +754,7 @@ spec:
               name: my-app
             patch: |
               - op: add
-                path: /metadata/annotations/helm.toolkit.fluxcd.io~1driftDetection
+                path: /metadata/annotations/cd.qdrant.io~1driftDetection
                 value: disabled
 ```
 
@@ -945,7 +945,7 @@ chart, you can set the `.spec.install.crds` and `.spec.upgrade.crds` policies to
 
 ```yaml
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: my-operator
@@ -1032,7 +1032,7 @@ The Service Account can then be referenced in the HelmRelease:
 
 ```yaml
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
  name: podinfo
@@ -1106,7 +1106,7 @@ spec:
 ---
 # ... unrelated Cluster API objects omitted for brevity ...
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack
@@ -1240,7 +1240,7 @@ In your YAML declaration:
 
 ```yaml
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: <helmrelease-name>
@@ -1266,7 +1266,7 @@ In your YAML declaration, comment out (or remove) the field:
 
 ```yaml
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: <helmrelease-name>
@@ -1404,7 +1404,7 @@ include the status of the tests which were run for each release.
 
 ```yaml
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: cd.qdrant.io/v2beta2
 kind: HelmRelease
 metadata:
   name: <release-name>

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ replace github.com/opencontainers/go-digest => github.com/opencontainers/go-dige
 
 // Pin kustomize to v5.4.3
 replace (
-	github.com/fluxcd/source-controller/api => github.com/qdrant/fluxcd-source-controller/api v0.0.0-20240423075159-9680b590c957
+	github.com/fluxcd/source-controller/api => github.com/qdrant/fluxcd-source-controller/api v0.0.0-20240814110651-c292ee968c96
 	sigs.k8s.io/kustomize/api => sigs.k8s.io/kustomize/api v0.17.3
 	sigs.k8s.io/kustomize/kyaml => sigs.k8s.io/kustomize/kyaml v0.17.2
 )

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/fluxcd/helm-controller
 
 go 1.22.0
 
-replace github.com/fluxcd/helm-controller/api => ./api
+replace (
+	github.com/fluxcd/helm-controller/api => ./api
+	github.com/fluxcd/helm-controller/internal => ./internal
+)
 
 // Replace digest lib to master to gather access to BLAKE3.
 // xref: https://github.com/opencontainers/go-digest/pull/66
@@ -10,6 +13,7 @@ replace github.com/opencontainers/go-digest => github.com/opencontainers/go-dige
 
 // Pin kustomize to v5.4.3
 replace (
+	github.com/fluxcd/source-controller/api => github.com/qdrant/fluxcd-source-controller/api v0.0.0-20240423075159-9680b590c957
 	sigs.k8s.io/kustomize/api => sigs.k8s.io/kustomize/api v0.17.3
 	sigs.k8s.io/kustomize/kyaml => sigs.k8s.io/kustomize/kyaml v0.17.2
 )

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ replace github.com/opencontainers/go-digest => github.com/opencontainers/go-dige
 
 // Pin kustomize to v5.4.3
 replace (
-	github.com/fluxcd/source-controller/api => github.com/qdrant/fluxcd-source-controller/api v0.0.0-20240814110651-c292ee968c96
+	github.com/fluxcd/source-controller/api => github.com/qdrant/fluxcd-source-controller/api v0.0.0-20240821122838-d650fb97fa04
 	sigs.k8s.io/kustomize/api => sigs.k8s.io/kustomize/api v0.17.3
 	sigs.k8s.io/kustomize/kyaml => sigs.k8s.io/kustomize/kyaml v0.17.2
 )

--- a/go.sum
+++ b/go.sum
@@ -346,8 +346,8 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
-github.com/qdrant/fluxcd-source-controller/api v0.0.0-20240814110651-c292ee968c96 h1:VBdL7YZ2zFz8Zq/u8glT43lSmR3F+J+zzu3ZiMHU67w=
-github.com/qdrant/fluxcd-source-controller/api v0.0.0-20240814110651-c292ee968c96/go.mod h1:+tfd0vltjcVs/bbnq9AlYR9AAHSVfM/Z4v4TpQmdJf4=
+github.com/qdrant/fluxcd-source-controller/api v0.0.0-20240821122838-d650fb97fa04 h1:RP32aF/Z8oAB31CWytM5uPSm1EV5cKGuIstHVUTg2QA=
+github.com/qdrant/fluxcd-source-controller/api v0.0.0-20240821122838-d650fb97fa04/go.mod h1:tBdalWxrxxHAJRB9HiXXYRBQQGM8wDe+ngK7wL+BN6A=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/rubenv/sql-migrate v1.5.2 h1:bMDqOnrJVV/6JQgQ/MxOpU+AdO8uzYYA/TxFUBzFtS0=

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,6 @@ github.com/fluxcd/pkg/ssa v0.41.0 h1:UFrnHJ/cT2+6Qoh98o7INipSoj8GjwMEtb9hLus15xQ
 github.com/fluxcd/pkg/ssa v0.41.0/go.mod h1:Lfu6g8AGbJ/MHSq5zSOBWMTJu9pPC5dG1ykmYC1NTPs=
 github.com/fluxcd/pkg/testserver v0.7.0 h1:kNVAn+3bAF2rfR9cT6SxzgEz2o84i+o7zKY3XRKTXmk=
 github.com/fluxcd/pkg/testserver v0.7.0/go.mod h1:Ih5IK3Y5G3+a6c77BTqFkdPDCY1Yj1A1W5cXQqkCs9s=
-github.com/fluxcd/source-controller/api v1.3.0 h1:Z5Lq0aJY87yg0cQDEuwGLKS60GhdErCHtsi546HUt10=
-github.com/fluxcd/source-controller/api v1.3.0/go.mod h1:+tfd0vltjcVs/bbnq9AlYR9AAHSVfM/Z4v4TpQmdJf4=
 github.com/foxcpp/go-mockdns v1.0.0 h1:7jBqxd3WDWwi/6WhDvacvH1XsN3rOLXyHM1uhvIx6FI=
 github.com/foxcpp/go-mockdns v1.0.0/go.mod h1:lgRN6+KxQBawyIghpnl5CezHFGS9VLzvtVlwxvzXTQ4=
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
@@ -348,6 +346,8 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
+github.com/qdrant/fluxcd-source-controller/api v0.0.0-20240423075159-9680b590c957 h1:ihu2wmod2Kk7QYmYxbbyoOW8lgygrLA1XGhNz//usRk=
+github.com/qdrant/fluxcd-source-controller/api v0.0.0-20240423075159-9680b590c957/go.mod h1:xoP+zd2WaboetJvIt4+KinjMUE09nTIARVDRiCTAzHs=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/rubenv/sql-migrate v1.5.2 h1:bMDqOnrJVV/6JQgQ/MxOpU+AdO8uzYYA/TxFUBzFtS0=

--- a/go.sum
+++ b/go.sum
@@ -346,8 +346,8 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
-github.com/qdrant/fluxcd-source-controller/api v0.0.0-20240423075159-9680b590c957 h1:ihu2wmod2Kk7QYmYxbbyoOW8lgygrLA1XGhNz//usRk=
-github.com/qdrant/fluxcd-source-controller/api v0.0.0-20240423075159-9680b590c957/go.mod h1:xoP+zd2WaboetJvIt4+KinjMUE09nTIARVDRiCTAzHs=
+github.com/qdrant/fluxcd-source-controller/api v0.0.0-20240814110651-c292ee968c96 h1:VBdL7YZ2zFz8Zq/u8glT43lSmR3F+J+zzu3ZiMHU67w=
+github.com/qdrant/fluxcd-source-controller/api v0.0.0-20240814110651-c292ee968c96/go.mod h1:+tfd0vltjcVs/bbnq9AlYR9AAHSVfM/Z4v4TpQmdJf4=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/rubenv/sql-migrate v1.5.2 h1:bMDqOnrJVV/6JQgQ/MxOpU+AdO8uzYYA/TxFUBzFtS0=

--- a/internal/controller/helmrelease_controller.go
+++ b/internal/controller/helmrelease_controller.go
@@ -73,13 +73,13 @@ import (
 	"github.com/fluxcd/helm-controller/internal/release"
 )
 
-// +kubebuilder:rbac:groups=helm.toolkit.fluxcd.io,resources=helmreleases,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=helm.toolkit.fluxcd.io,resources=helmreleases/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=helm.toolkit.fluxcd.io,resources=helmreleases/finalizers,verbs=get;create;update;patch;delete
-// +kubebuilder:rbac:groups=source.toolkit.fluxcd.io,resources=helmcharts,verbs=get;list;watch
-// +kubebuilder:rbac:groups=source.toolkit.fluxcd.io,resources=helmcharts/status,verbs=get
-// +kubebuilder:rbac:groups=source.toolkit.fluxcd.io,resources=ocirepositories,verbs=get;list;watch
-// +kubebuilder:rbac:groups=source.toolkit.fluxcd.io,resources=ocirepositories/status,verbs=get
+// +kubebuilder:rbac:groups=cd.qdrant.io,resources=helmreleases,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=cd.qdrant.io,resources=helmreleases/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=cd.qdrant.io,resources=helmreleases/finalizers,verbs=get;create;update;patch;delete
+// +kubebuilder:rbac:groups=cd.qdrant.io,resources=helmcharts,verbs=get;list;watch
+// +kubebuilder:rbac:groups=cd.qdrant.io,resources=helmcharts/status,verbs=get
+// +kubebuilder:rbac:groups=cd.qdrant.io,resources=ocirepositories,verbs=get;list;watch
+// +kubebuilder:rbac:groups=cd.qdrant.io,resources=ocirepositories/status,verbs=get
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 // HelmReleaseReconciler reconciles a HelmRelease object.

--- a/internal/controller/helmrelease_controller.go
+++ b/internal/controller/helmrelease_controller.go
@@ -91,6 +91,7 @@ type HelmReleaseReconciler struct {
 	GetClusterConfig func() (*rest.Config, error)
 	ClientOpts       runtimeClient.Options
 	KubeConfigOpts   runtimeClient.KubeConfigOptions
+	LeaderElection   *bool
 
 	FieldManager          string
 	DefaultServiceAccount string
@@ -145,7 +146,8 @@ func (r *HelmReleaseReconciler) SetupWithManager(ctx context.Context, mgr ctrl.M
 			builder.WithPredicates(intpredicates.SourceRevisionChangePredicate{}),
 		).
 		WithOptions(controller.Options{
-			RateLimiter: opts.RateLimiter,
+			RateLimiter:        opts.RateLimiter,
+			NeedLeaderElection: r.LeaderElection,
 		}).
 		Complete(r)
 }

--- a/internal/postrender/origin_labels_test.go
+++ b/internal/postrender/origin_labels_test.go
@@ -50,8 +50,8 @@ func Test_OriginLabels_Run(t *testing.T) {
 kind: Pod
 metadata:
   labels:
-    helm.toolkit.fluxcd.io/name: name
-    helm.toolkit.fluxcd.io/namespace: namespace
+    cd.qdrant.io/name: name
+    cd.qdrant.io/namespace: namespace
   name: pod-without-labels
 ---
 apiVersion: v1
@@ -69,7 +69,7 @@ metadata:
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			k := NewOriginLabels("helm.toolkit.fluxcd.io", "namespace", "name")
+			k := NewOriginLabels("cd.qdrant.io", "namespace", "name")
 			gotModifiedManifests, err := k.Run(bytes.NewBufferString(tt.renderedManifests))
 			if tt.expectErr {
 				g.Expect(err).To(HaveOccurred())

--- a/internal/postrender/origin_labels_test.go
+++ b/internal/postrender/origin_labels_test.go
@@ -58,9 +58,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    cd.qdrant.io/name: name
+    cd.qdrant.io/namespace: namespace
     existing: label
-    helm.toolkit.fluxcd.io/name: name
-    helm.toolkit.fluxcd.io/namespace: namespace
   name: service-with-labels
 `,
 		},

--- a/scripts/rename-api-groups.sh
+++ b/scripts/rename-api-groups.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+declare -A replacements
+
+replacements=(
+    ["group: helm.toolkit.fluxcd.io"]="group: cd.qdrant.io"
+    ["source.toolkit.fluxcd.io"]="cd.qdrant.io"
+    ["finalizers.fluxcd.io"]="finalizers.qdrant.io"
+    ["domain: toolkit.fluxcd.io"]="domain: qdrant.io"
+    ["group: helm$"]="group: cd"
+    ["helm.toolkit.fluxcd.io"]="cd.qdrant.io"
+    ["shortName=hr"]="shortName=qdranthr"
+)
+
+replace_files_content() {
+    for pattern in "${!replacements[@]}"; do
+        echo "Renaming '$pattern' to '${replacements[$pattern]}'"
+        find . -type f \( -name '*.go' -o -name '*.yml' -o -name '*.yaml' -o -path './docs/*.md'  -o -name 'PROJECT' \) | xargs sed -i '' "s/$pattern/${replacements[$pattern]}/g"
+    done
+
+    # special ones (multiline)
+    find . -type f \( -name '*.go' -o -name '*.yml' -o -name '*.yaml' -o -path './docs/*.md' -o -name 'PROJECT' \) | xargs sed -i '' '/shortNames:/,/^ *-/s/- hr/- qdranthr/'
+}
+
+copy_crd_base_files() {
+    old_pattern="helm.toolkit.fluxcd.io"
+    new_pattern="cd.qdrant.io"
+    for file in config/crd/bases/*.yaml; do
+        new_filename=`echo $file | sed s/$old_pattern/$new_pattern/g`
+        echo "Copying '$file' to '$new_filename'"
+        cp $file $new_filename
+    done
+}
+
+# For some reason in the original patch we were keeping the original files. We
+# do the same here. We use git restore to undo the changes made by the call to
+# `replace_files_content`.
+restore_original_crd_base_files() {
+    git restore config/crd/bases/helm*
+}
+
+replace_files_content
+copy_crd_base_files
+restore_original_crd_base_files


### PR DESCRIPTION
Related: https://github.com/qdrant/cloud-pm/issues/1282

Currently, main branch is up to date with upstream/main. This PR contains:

- The original changes we did to the project + **small change to make it work with the new k8s versions** (`v0.31.0`).
- Updated source-controller to use the code from [this PR](https://github.com/qdrant/fluxcd-source-controller/pull/6).
- More renaming of the api groups. I tried to unify the renaming rules we were manually applying and put them in a script. Besides automating the process, we have it as a reference of what we're modifying. I applied consistently through all the project.
- Finally, I added some instructions in the readme about how to keep the project up to date and the script to rename the api groups.